### PR TITLE
Fix range hood light level availability error

### DIFF
--- a/custom_components/ge_home/entities/hood/ge_hood_light_level.py
+++ b/custom_components/ge_home/entities/hood/ge_hood_light_level.py
@@ -16,7 +16,7 @@ class HoodLightLevelOptionsConverter(OptionsConverter):
             self.excluded_levels.append(ErdHoodLightLevel.OFF)
         if not availability.dim_available:
             self.excluded_levels.append(ErdHoodLightLevel.DIM)
-        if not availability.on_available:
+        if not availability.high_available:
             self.excluded_levels.append(ErdHoodLightLevel.HIGH)
 
     @property


### PR DESCRIPTION
It looks like `high_available` is what's [currently used in gehomesdk](https://github.com/simbaja/gehome/blob/master/gehomesdk/erd/values/hood/erd_hood_light_level_availability.py). This change got my GE Cafe up and running 👍 