### PR TITLE
Add support for fridges with reduced support for ERD codes

### DIFF
--- a/custom_components/ge_home/entities/fridge/ge_freezer.py
+++ b/custom_components/ge_home/entities/fridge/ge_freezer.py
@@ -26,7 +26,10 @@ class GeFreezer(GeAbstractFridge):
 
     @property
     def door_state_attrs(self) -> Optional[Dict[str, Any]]:
-        door_status = self.door_status.freezer
-        if door_status and door_status != ErdDoorStatus.NA:
-            return {ATTR_DOOR_STATUS: self._stringify(door_status)}
+        try:
+            door_status = self.door_status.freezer
+            if door_status and door_status != ErdDoorStatus.NA:
+                return {ATTR_DOOR_STATUS: self._stringify(door_status)}
+        except:
+            _LOGGER.debug("Device does not report door status.")
         return {}

--- a/custom_components/ge_home/entities/fridge/ge_fridge.py
+++ b/custom_components/ge_home/entities/fridge/ge_fridge.py
@@ -36,23 +36,27 @@ class GeFridge(GeAbstractFridge):
     @property
     def door_state_attrs(self) -> Dict[str, Any]:
         """Get state attributes for the doors."""
-        data = {}
-        door_status = self.door_status
-        if not door_status:
+        try:
+            data = {}
+            door_status = self.door_status
+            if not door_status:
+                return {}
+            door_right = door_status.fridge_right
+            door_left = door_status.fridge_left
+            drawer = door_status.drawer
+
+            if door_right and door_right != ErdDoorStatus.NA:
+                data["right_door"] = door_status.fridge_right.name.title()
+            if door_left and door_left != ErdDoorStatus.NA:
+                data["left_door"] = door_status.fridge_left.name.title()
+            if drawer and drawer != ErdDoorStatus.NA:
+                data["drawer"] = door_status.drawer.name.title()
+
+            if data:
+                all_closed = all(v == "Closed" for v in data.values())
+                data[ATTR_DOOR_STATUS] = "Closed" if all_closed else "Open"
+
+            return data
+        except:
+            _LOGGER.debug("Device does not report door status.")
             return {}
-        door_right = door_status.fridge_right
-        door_left = door_status.fridge_left
-        drawer = door_status.drawer
-
-        if door_right and door_right != ErdDoorStatus.NA:
-            data["right_door"] = door_status.fridge_right.name.title()
-        if door_left and door_left != ErdDoorStatus.NA:
-            data["left_door"] = door_status.fridge_left.name.title()
-        if drawer and drawer != ErdDoorStatus.NA:
-            data["drawer"] = door_status.drawer.name.title()
-
-        if data:
-            all_closed = all(v == "Closed" for v in data.values())
-            data[ATTR_DOOR_STATUS] = "Closed" if all_closed else "Open"
-
-        return data


### PR DESCRIPTION
Please accept this pull request to support fridges with reduced support for ERD codes, including:
- no turbo mode
- no current temperature reporting
- no temperature setpoint limit reporting
- no door status reporting
This change has been tested on a Fisher & Paykel RF610AA. Thanks!