### PR TITLE
Check for upper oven light when there is a lower oven

### DIFF
--- a/custom_components/ge_home/devices/oven.py
+++ b/custom_components/ge_home/devices/oven.py
@@ -75,6 +75,8 @@ class OvenApi(ApplianceApi):
             ])
             if has_upper_raw_temperature:
                 oven_entities.append(GeErdSensor(self, ErdCode.UPPER_OVEN_RAW_TEMPERATURE))
+            if upper_light_availability is None or upper_light_availability.is_available or upper_light is not None:
+                oven_entities.append(GeOvenLightLevelSelect(self, ErdCode.UPPER_OVEN_LIGHT))
             if has_lower_raw_temperature:
                 oven_entities.append(GeErdSensor(self, ErdCode.LOWER_OVEN_RAW_TEMPERATURE))
             if lower_light_availability is None or lower_light_availability.is_available or lower_light is not None:


### PR DESCRIPTION
Resolves issue #121

Both lights are detected properly, and I can turn both on/off.

<img width="333" alt="Screenshot 2023-06-16 at 10 58 34 PM" src="https://github.com/simbaja/ha_gehome/assets/154074/7559cc2f-a05d-4e7c-ab77-5368c5a7b0d9">
