### PR TITLE
Fix RuntimeError: Attribute hass is None for <Entity ...>

### DIFF
--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -64,8 +64,6 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
 
         self._reset_initialization()
 
-        super().__init__(hass, _LOGGER, name=DOMAIN)
-
     def _reset_initialization(self):
         self.client = None  # type: Optional[GeWebsocketClient]
 

--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -55,7 +55,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Set up the GeHomeUpdateCoordinator class."""
-        self._hass = hass
+        self.hass = hass
         self._config_entry = config_entry
         self._username = config_entry.data[CONF_USERNAME]
         self._password = config_entry.data[CONF_PASSWORD]
@@ -161,7 +161,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
             finally:
                 self._reset_initialization()
 
-        loop = self._hass.loop
+        loop = self.hass.loop
         self.client = self.create_ge_client(event_loop=loop)
         return self.client
 
@@ -201,9 +201,9 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
     async def async_begin_session(self):
         """Begins the ge_home session."""
         _LOGGER.debug("Beginning session")
-        session = self._hass.helpers.aiohttp_client.async_get_clientsession()
+        session = self.hass.helpers.aiohttp_client.async_get_clientsession()
         await self.client.async_get_credentials(session)
-        fut = asyncio.ensure_future(self.client.async_run_client(), loop=self._hass.loop)
+        fut = asyncio.ensure_future(self.client.async_run_client(), loop=self.hass.loop)
         _LOGGER.debug("Client running")
         return fut
 
@@ -263,7 +263,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.info("ge_home shutting down")
         if self.client:
             self.client.clear_event_handlers()
-            self._hass.loop.create_task(self.client.disconnect())
+            self.hass.loop.create_task(self.client.disconnect())
 
     async def on_device_update(self, data: Tuple[GeAppliance, Dict[ErdCodeType, Any]]):
         """Let HA know there's new state."""


### PR DESCRIPTION
Greetings! I've seen the following error in my HA logs:

```
2023-10-29 07:57:08.393 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved:   File "/usr/local/bin/hass", line 8, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 204, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 186, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 640, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 607, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 1914, in _run_once
    handle._run()
  File "/usr/local/lib/python3.11/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/lib/python3.11/site-packages/gehomesdk/clients/base_client.py", line 132, in async_run_client
    await self._async_run_client()
  File "/usr/local/lib/python3.11/site-packages/gehomesdk/clients/websocket_client.py", line 119, in _async_run_client
    await self._process_message(message)
  File "/usr/local/lib/python3.11/site-packages/gehomesdk/clients/websocket_client.py", line 293, in _process_message
    await self._process_cache_update(message_dict)
  File "/usr/local/lib/python3.11/site-packages/gehomesdk/clients/websocket_client.py", line 409, in _process_cache_update
    await self._update_appliance_state(mac_addr, updates)
  File "/usr/local/lib/python3.11/site-packages/gehomesdk/clients/websocket_client.py", line 445, in _update_appliance_state
    await self.async_event(EVENT_APPLIANCE_UPDATE_RECEIVED, [appliance, updates])
  File "/usr/local/lib/python3.11/site-packages/gehomesdk/clients/base_client.py", line 101, in async_event
    asyncio.ensure_future(cb(*args, **kwargs), loop=self.loop)
  File "/usr/local/lib/python3.11/asyncio/tasks.py", line 649, in ensure_future
    return _ensure_future(coro_or_future, loop=loop)
  File "/usr/local/lib/python3.11/asyncio/tasks.py", line 670, in _ensure_future
    return loop.create_task(coro_or_future)
Traceback (most recent call last):
  File "/root/.homeassistant/custom_components/ge_home/update_coordinator.py", line 280, in on_device_update
    entity.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 756, in async_write_ha_state
    raise RuntimeError(f"Attribute hass is None for {self}")
RuntimeError: Attribute hass is None for <Entity EID Cook Mode>
```

I started digging in a little bit and came across the two references to the same `hass` object. This PR removes the reinitialization of the class's properties e.g. `entity_id` via the `super` method call. Happy to add any necessary tests or discuss further. Thank you!