### PR TITLE
Set device class on day flow for water filters

### DIFF
--- a/custom_components/ge_home/devices/water_filter.py
+++ b/custom_components/ge_home/devices/water_filter.py
@@ -30,7 +30,7 @@ class WaterFilterApi(ApplianceApi):
             GeErdBinarySensor(self, ErdCode.WH_FILTER_MANUAL_MODE, icon_on_override="mdi:human", icon_off_override="mdi:robot"),
             GeErdBinarySensor(self, ErdCode.WH_FILTER_LEAK_VALIDITY, device_class_override="moisture"),
             GeErdPropertySensor(self, ErdCode.WH_FILTER_FLOW_RATE, "flow_rate"),
-            GeErdSensor(self, ErdCode.WH_FILTER_DAY_USAGE),
+            GeErdSensor(self, ErdCode.WH_FILTER_DAY_USAGE, device_class_override="water"),
             GeErdPropertySensor(self, ErdCode.WH_FILTER_LIFE_REMAINING, "life_remaining"),
             GeErdBinarySensor(self, ErdCode.WH_FILTER_FLOW_ALERT, device_class_override="moisture"),
         ]


### PR DESCRIPTION
Same fix as #207, but for filters.