### PR TITLE
Update Deprecated Constants or Remove Unused Ones

### DIFF
--- a/custom_components/ge_home/devices/cooktop.py
+++ b/custom_components/ge_home/devices/cooktop.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 from gehomesdk.erd.erd_data_type import ErdDataType
 
-from homeassistant.const import DEVICE_CLASS_POWER_FACTOR
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.helpers.entity import Entity
 from gehomesdk import (
     ErdCode, 
@@ -44,7 +44,7 @@ class CooktopApi(ApplianceApi):
                     cooktop_entities.append(GeErdPropertyBinarySensor(self, ErdCode.COOKTOP_STATUS, prop+".on"))
                     cooktop_entities.append(GeErdPropertyBinarySensor(self, ErdCode.COOKTOP_STATUS, prop+".synchronized"))                    
                     if not v.on_off_only:
-                        cooktop_entities.append(GeErdPropertySensor(self, ErdCode.COOKTOP_STATUS, prop+".power_pct", icon_override="mdi:fire", device_class_override=DEVICE_CLASS_POWER_FACTOR, data_type_override=ErdDataType.INT))
+                        cooktop_entities.append(GeErdPropertySensor(self, ErdCode.COOKTOP_STATUS, prop+".power_pct", icon_override="mdi:fire", device_class_override=SensorDeviceClass.POWER_FACTOR, data_type_override=ErdDataType.INT))
 
         return base_entities + cooktop_entities
 

--- a/custom_components/ge_home/devices/fridge.py
+++ b/custom_components/ge_home/devices/fridge.py
@@ -1,5 +1,5 @@
 from homeassistant.components.binary_sensor import DEVICE_CLASS_PROBLEM
-from homeassistant.const import DEVICE_CLASS_TEMPERATURE
+from homeassistant.components.sensor import SensorDeviceClass
 import logging
 from typing import List
 
@@ -117,7 +117,7 @@ class FridgeApi(ApplianceApi):
                 GeErdSensor(self, ErdCode.HOT_WATER_SET_TEMP),
                 GeErdPropertySensor(self, ErdCode.HOT_WATER_STATUS, "status", icon_override="mdi:information-outline"),
                 GeErdPropertySensor(self, ErdCode.HOT_WATER_STATUS, "time_until_ready", icon_override="mdi:timer-outline"),
-                GeErdPropertySensor(self, ErdCode.HOT_WATER_STATUS, "current_temp", device_class_override=DEVICE_CLASS_TEMPERATURE, data_type_override=ErdDataType.INT),
+                GeErdPropertySensor(self, ErdCode.HOT_WATER_STATUS, "current_temp", device_class_override=SensorDeviceClass.TEMPERATURE, data_type_override=ErdDataType.INT),
                 GeErdPropertyBinarySensor(self, ErdCode.HOT_WATER_STATUS, "faulted", device_class_override=DEVICE_CLASS_PROBLEM),
                 GeDispenser(self)
             ])

--- a/custom_components/ge_home/devices/oven.py
+++ b/custom_components/ge_home/devices/oven.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 from gehomesdk.erd.erd_data_type import ErdDataType
 
-from homeassistant.const import DEVICE_CLASS_POWER_FACTOR
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.helpers.entity import Entity
 from gehomesdk import (
     ErdCode, 
@@ -111,7 +111,7 @@ class OvenApi(ApplianceApi):
                         cooktop_entities.append(GeErdPropertyBinarySensor(self, ErdCode.COOKTOP_STATUS, prop+".on"))
                         cooktop_entities.append(GeErdPropertyBinarySensor(self, ErdCode.COOKTOP_STATUS, prop+".synchronized"))                    
                         if not v.on_off_only:
-                            cooktop_entities.append(GeErdPropertySensor(self, ErdCode.COOKTOP_STATUS, prop+".power_pct", icon_override="mdi:fire", device_class_override=DEVICE_CLASS_POWER_FACTOR, data_type_override=ErdDataType.INT))
+                            cooktop_entities.append(GeErdPropertySensor(self, ErdCode.COOKTOP_STATUS, prop+".power_pct", icon_override="mdi:fire", device_class_override=SensorDeviceClass.POWER_FACTOR, data_type_override=ErdDataType.INT))
 
         return base_entities + oven_entities + cooktop_entities
 

--- a/custom_components/ge_home/entities/ac/fan_mode_options.py
+++ b/custom_components/ge_home/entities/ac/fan_mode_options.py
@@ -1,11 +1,6 @@
 import logging
 from typing import Any, List, Optional
 
-from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_FAN_ONLY,
-)
 from gehomesdk import ErdAcFanSetting
 from ..common import OptionsConverter
 

--- a/custom_components/ge_home/entities/ac/ge_biac_climate.py
+++ b/custom_components/ge_home/entities/ac/ge_biac_climate.py
@@ -1,11 +1,7 @@
 import logging
 from typing import Any, List, Optional
 
-from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_FAN_ONLY,
-)
+from homeassistant.components.climate import HVACMode
 from gehomesdk import ErdAcOperationMode
 from ...devices import ApplianceApi
 from ..common import GeClimate, OptionsConverter
@@ -16,13 +12,13 @@ _LOGGER = logging.getLogger(__name__)
 class BiacHvacModeOptionsConverter(OptionsConverter):
     @property
     def options(self) -> List[str]:
-        return [HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_FAN_ONLY]
+        return [HVACMode.AUTO, HVACMode.COOL, HVACMode.FAN_ONLY]
     def from_option_string(self, value: str) -> Any:
         try:
             return {
-                HVAC_MODE_AUTO: ErdAcOperationMode.ENERGY_SAVER,
-                HVAC_MODE_COOL: ErdAcOperationMode.COOL,
-                HVAC_MODE_FAN_ONLY: ErdAcOperationMode.FAN_ONLY
+                HVACMode.AUTO: ErdAcOperationMode.ENERGY_SAVER,
+                HVACMode.COOL: ErdAcOperationMode.COOL,
+                HVACMode.FAN_ONLY: ErdAcOperationMode.FAN_ONLY
             }.get(value)
         except:
             _LOGGER.warn(f"Could not set HVAC mode to {value.upper()}")
@@ -30,14 +26,14 @@ class BiacHvacModeOptionsConverter(OptionsConverter):
     def to_option_string(self, value: Any) -> Optional[str]:
         try:
             return {
-                ErdAcOperationMode.ENERGY_SAVER: HVAC_MODE_AUTO,
-                ErdAcOperationMode.AUTO: HVAC_MODE_AUTO,
-                ErdAcOperationMode.COOL: HVAC_MODE_COOL,
-                ErdAcOperationMode.FAN_ONLY: HVAC_MODE_FAN_ONLY
+                ErdAcOperationMode.ENERGY_SAVER: HVACMode.AUTO,
+                ErdAcOperationMode.AUTO: HVACMode.AUTO,
+                ErdAcOperationMode.COOL: HVACMode.COOL,
+                ErdAcOperationMode.FAN_ONLY: HVACMode.FAN_ONLY
             }.get(value)
         except:
             _LOGGER.warn(f"Could not determine operation mode mapping for {value}")
-            return HVAC_MODE_COOL
+            return HVACMode.COOL
   
 class GeBiacClimate(GeClimate):
     """Class for Built-In AC units"""

--- a/custom_components/ge_home/entities/ac/ge_pac_climate.py
+++ b/custom_components/ge_home/entities/ac/ge_pac_climate.py
@@ -1,17 +1,7 @@
 import logging
 from typing import Any, List, Optional
 
-
-from homeassistant.const import (
-    TEMP_FAHRENHEIT
-)
-from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_FAN_ONLY,
-    HVAC_MODE_HEAT,
-)
+from homeassistant.components.climate import HVACMode
 from gehomesdk import ErdCode, ErdAcOperationMode, ErdSacAvailableModes, ErdSacTargetTemperatureRange
 from ...devices import ApplianceApi
 from ..common import GeClimate, OptionsConverter
@@ -25,19 +15,19 @@ class PacHvacModeOptionsConverter(OptionsConverter):
 
     @property
     def options(self) -> List[str]:
-        modes = [HVAC_MODE_COOL, HVAC_MODE_FAN_ONLY]
+        modes = [HVACMode.COOL, HVACMode.FAN_ONLY]
         if self._available_modes and self._available_modes.has_heat:
-            modes.append(HVAC_MODE_HEAT)
+            modes.append(HVACMode.HEAT)
         if self._available_modes and self._available_modes.has_dry:
-            modes.append(HVAC_MODE_DRY)
+            modes.append(HVACMode.DRY)
         return modes
     def from_option_string(self, value: str) -> Any:
         try:
             return {
-                HVAC_MODE_COOL: ErdAcOperationMode.COOL,
-                HVAC_MODE_HEAT: ErdAcOperationMode.HEAT,
-                HVAC_MODE_FAN_ONLY: ErdAcOperationMode.FAN_ONLY,
-                HVAC_MODE_DRY: ErdAcOperationMode.DRY
+                HVACMode.COOL: ErdAcOperationMode.COOL,
+                HVACMode.HEAT: ErdAcOperationMode.HEAT,
+                HVACMode.FAN_ONLY: ErdAcOperationMode.FAN_ONLY,
+                HVACMode.DRY: ErdAcOperationMode.DRY
             }.get(value)
         except:
             _LOGGER.warn(f"Could not set HVAC mode to {value.upper()}")
@@ -45,14 +35,14 @@ class PacHvacModeOptionsConverter(OptionsConverter):
     def to_option_string(self, value: Any) -> Optional[str]:
         try:
             return {
-                ErdAcOperationMode.COOL: HVAC_MODE_COOL,
-                ErdAcOperationMode.HEAT: HVAC_MODE_HEAT,
-                ErdAcOperationMode.DRY: HVAC_MODE_DRY,
-                ErdAcOperationMode.FAN_ONLY: HVAC_MODE_FAN_ONLY
+                ErdAcOperationMode.COOL: HVACMode.COOL,
+                ErdAcOperationMode.HEAT: HVACMode.HEAT,
+                ErdAcOperationMode.DRY: HVACMode.DRY,
+                ErdAcOperationMode.FAN_ONLY: HVACMode.FAN_ONLY
             }.get(value)
         except:
             _LOGGER.warn(f"Could not determine operation mode mapping for {value}")
-            return HVAC_MODE_COOL
+            return HVACMode.COOL
      
 class GePacClimate(GeClimate):
     """Class for Portable AC units"""

--- a/custom_components/ge_home/entities/ac/ge_sac_climate.py
+++ b/custom_components/ge_home/entities/ac/ge_sac_climate.py
@@ -1,16 +1,7 @@
 import logging
 from typing import Any, List, Optional
 
-from homeassistant.const import (
-    TEMP_FAHRENHEIT
-)
-from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_FAN_ONLY,
-    HVAC_MODE_HEAT,
-)
+from homeassistant.components.climate import HVACMode
 from gehomesdk import ErdCode, ErdAcOperationMode, ErdSacAvailableModes, ErdSacTargetTemperatureRange
 from ...devices import ApplianceApi
 from ..common import GeClimate, OptionsConverter
@@ -24,21 +15,21 @@ class SacHvacModeOptionsConverter(OptionsConverter):
 
     @property
     def options(self) -> List[str]:
-        modes = [HVAC_MODE_COOL, HVAC_MODE_FAN_ONLY]
+        modes = [HVACMode.COOL, HVACMode.FAN_ONLY]
         if self._available_modes and self._available_modes.has_heat:
-            modes.append(HVAC_MODE_HEAT)
-            modes.append(HVAC_MODE_AUTO)
+            modes.append(HVACMode.HEAT)
+            modes.append(HVACMode.AUTO)
         if self._available_modes and self._available_modes.has_dry:
-            modes.append(HVAC_MODE_DRY)
+            modes.append(HVACMode.DRY)
         return modes
     def from_option_string(self, value: str) -> Any:
         try:
             return {
-                HVAC_MODE_AUTO: ErdAcOperationMode.AUTO,
-                HVAC_MODE_COOL: ErdAcOperationMode.COOL,
-                HVAC_MODE_HEAT: ErdAcOperationMode.HEAT,
-                HVAC_MODE_FAN_ONLY: ErdAcOperationMode.FAN_ONLY,
-                HVAC_MODE_DRY: ErdAcOperationMode.DRY
+                HVACMode.AUTO: ErdAcOperationMode.AUTO,
+                HVACMode.COOL: ErdAcOperationMode.COOL,
+                HVACMode.HEAT: ErdAcOperationMode.HEAT,
+                HVACMode.FAN_ONLY: ErdAcOperationMode.FAN_ONLY,
+                HVACMode.DRY: ErdAcOperationMode.DRY
             }.get(value)
         except:
             _LOGGER.warn(f"Could not set HVAC mode to {value.upper()}")
@@ -46,16 +37,16 @@ class SacHvacModeOptionsConverter(OptionsConverter):
     def to_option_string(self, value: Any) -> Optional[str]:
         try:
             return {
-                ErdAcOperationMode.ENERGY_SAVER: HVAC_MODE_AUTO,
-                ErdAcOperationMode.AUTO: HVAC_MODE_AUTO,
-                ErdAcOperationMode.COOL: HVAC_MODE_COOL,
-                ErdAcOperationMode.HEAT: HVAC_MODE_HEAT,
-                ErdAcOperationMode.DRY: HVAC_MODE_DRY,
-                ErdAcOperationMode.FAN_ONLY: HVAC_MODE_FAN_ONLY
+                ErdAcOperationMode.ENERGY_SAVER: HVACMode.AUTO,
+                ErdAcOperationMode.AUTO: HVACMode.AUTO,
+                ErdAcOperationMode.COOL: HVACMode.COOL,
+                ErdAcOperationMode.HEAT: HVACMode.HEAT,
+                ErdAcOperationMode.DRY: HVACMode.DRY,
+                ErdAcOperationMode.FAN_ONLY: HVACMode.FAN_ONLY
             }.get(value)
         except:
             _LOGGER.warn(f"Could not determine operation mode mapping for {value}")
-            return HVAC_MODE_COOL
+            return HVACMode.COOL
       
 class GeSacClimate(GeClimate):
     """Class for Split AC units"""

--- a/custom_components/ge_home/entities/ac/ge_wac_climate.py
+++ b/custom_components/ge_home/entities/ac/ge_wac_climate.py
@@ -1,11 +1,7 @@
 import logging
 from typing import Any, List, Optional
 
-from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_FAN_ONLY,
-)
+from homeassistant.components.climate import HVACMode
 from gehomesdk import ErdAcOperationMode
 from ...devices import ApplianceApi
 from ..common import GeClimate, OptionsConverter
@@ -16,13 +12,13 @@ _LOGGER = logging.getLogger(__name__)
 class WacHvacModeOptionsConverter(OptionsConverter):
     @property
     def options(self) -> List[str]:
-        return [HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_FAN_ONLY]
+        return [HVACMode.AUTO, HVACMode.COOL, HVACMode.FAN_ONLY]
     def from_option_string(self, value: str) -> Any:
         try:
             return {
-                HVAC_MODE_AUTO: ErdAcOperationMode.ENERGY_SAVER,
-                HVAC_MODE_COOL: ErdAcOperationMode.COOL,
-                HVAC_MODE_FAN_ONLY: ErdAcOperationMode.FAN_ONLY
+                HVACMode.AUTO: ErdAcOperationMode.ENERGY_SAVER,
+                HVACMode.COOL: ErdAcOperationMode.COOL,
+                HVACMode.FAN_ONLY: ErdAcOperationMode.FAN_ONLY
             }.get(value)
         except:
             _LOGGER.warn(f"Could not set HVAC mode to {value.upper()}")
@@ -30,14 +26,14 @@ class WacHvacModeOptionsConverter(OptionsConverter):
     def to_option_string(self, value: Any) -> Optional[str]:
         try:
             return {
-                ErdAcOperationMode.ENERGY_SAVER: HVAC_MODE_AUTO,
-                ErdAcOperationMode.AUTO: HVAC_MODE_AUTO,
-                ErdAcOperationMode.COOL: HVAC_MODE_COOL,
-                ErdAcOperationMode.FAN_ONLY: HVAC_MODE_FAN_ONLY
+                ErdAcOperationMode.ENERGY_SAVER: HVACMode.AUTO,
+                ErdAcOperationMode.AUTO: HVACMode.AUTO,
+                ErdAcOperationMode.COOL: HVACMode.COOL,
+                ErdAcOperationMode.FAN_ONLY: HVACMode.FAN_ONLY
             }.get(value)
         except:
             _LOGGER.warn(f"Could not determine operation mode mapping for {value}")
-            return HVAC_MODE_COOL
+            return HVACMode.COOL
   
 class GeWacClimate(GeClimate):
     """Class for Window AC units"""

--- a/custom_components/ge_home/entities/advantium/const.py
+++ b/custom_components/ge_home/entities/advantium/const.py
@@ -1,8 +1,5 @@
-from homeassistant.components.water_heater import (
-    SUPPORT_OPERATION_MODE,
-    SUPPORT_TARGET_TEMPERATURE
-)
+from homeassistant.components.water_heater import WaterHeaterEntityFeature
 
 SUPPORT_NONE = 0
-GE_ADVANTIUM_WITH_TEMPERATURE = (SUPPORT_OPERATION_MODE | SUPPORT_TARGET_TEMPERATURE)
-GE_ADVANTIUM = SUPPORT_OPERATION_MODE
+GE_ADVANTIUM_WITH_TEMPERATURE = (WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.TARGET_TEMPERATURE)
+GE_ADVANTIUM = WaterHeaterEntityFeature.OPERATION_MODE

--- a/custom_components/ge_home/entities/advantium/ge_advantium.py
+++ b/custom_components/ge_home/entities/advantium/ge_advantium.py
@@ -15,7 +15,8 @@ from gehomesdk import (
 )
 from gehomesdk.erd.values.advantium.advantium_enums import CookAction, CookMode
 
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import ATTR_TEMPERATURE
 from ...const import DOMAIN
 from ...devices import ApplianceApi
 from ..common import GeAbstractWaterHeater
@@ -272,7 +273,7 @@ class GeAdvantium(GeAbstractWaterHeater):
     async def _convert_target_temperature(self, temp_120v: int, temp_240v: int):
         unit_type = self.unit_type
         target_temp_f = temp_240v if unit_type in [ErdUnitType.TYPE_240V_MONOGRAM, ErdUnitType.TYPE_240V_CAFE] else temp_120v
-        if self.temperature_unit == TEMP_FAHRENHEIT:
+        if self.temperature_unit == SensorDeviceClass.FAHRENHEIT:
             return float(target_temp_f)
         else:
             return (target_temp_f - 32.0) * (5/9)

--- a/custom_components/ge_home/entities/ccm/ge_ccm_brew_temperature.py
+++ b/custom_components/ge_home/entities/ccm/ge_ccm_brew_temperature.py
@@ -2,7 +2,6 @@ from gehomesdk import ErdCode
 from ...devices import ApplianceApi
 from ..common import GeErdNumber
 from .ge_ccm_cached_value import GeCcmCachedValue
-from homeassistant.const import TEMP_FAHRENHEIT
 
 class GeCcmBrewTemperatureNumber(GeErdNumber, GeCcmCachedValue):
     def __init__(self, api: ApplianceApi):

--- a/custom_components/ge_home/entities/common/ge_erd_number.py
+++ b/custom_components/ge_home/entities/common/ge_erd_number.py
@@ -5,7 +5,7 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberDeviceClass,
 )
-from homeassistant.const import TEMP_FAHRENHEIT
+from homeassistant.const import UnitOfTemperature
 from gehomesdk import ErdCodeType, ErdCodeClass
 from .ge_erd_entity import GeErdEntity
 from ...devices import ApplianceApi
@@ -91,7 +91,7 @@ class GeErdNumber(GeErdEntity, NumberEntity):
             #NOTE: it appears that the API only sets temperature in Fahrenheit,
             #so we'll hard code this UOM instead of using the device configured
             #settings
-            return TEMP_FAHRENHEIT
+            return UnitOfTemperature.FAHRENHEIT
         
         return None
 

--- a/custom_components/ge_home/entities/common/ge_erd_sensor.py
+++ b/custom_components/ge_home/entities/common/ge_erd_sensor.py
@@ -1,17 +1,9 @@
 import logging
 from typing import Optional
 from gehomesdk.erd.erd_data_type import ErdDataType
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 
-from homeassistant.const import (
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_POWER_FACTOR,
-    DEVICE_CLASS_HUMIDITY,
-    TEMP_FAHRENHEIT,
-)
+from homeassistant.const import UnitOfTemperature
 from gehomesdk import ErdCodeType, ErdCodeClass
 from .ge_erd_entity import GeErdEntity
 from ...devices import ApplianceApi
@@ -76,8 +68,8 @@ class GeErdSensor(GeErdEntity, SensorEntity):
         return self.api.hass.config.units.temperature_unit
 
         #if self._measurement_system == ErdMeasurementUnits.METRIC:
-        #    return TEMP_CELSIUS
-        #return TEMP_FAHRENHEIT
+        #    return UnitOfTemperature.CELSIUS
+        #return UnitOfTemperature.FAHRENHEIT
 
     def _convert_numeric_value_from_device(self, value):
         """Convert to expected data type"""
@@ -97,20 +89,20 @@ class GeErdSensor(GeErdEntity, SensorEntity):
         if (
             self.erd_code_class
             in [ErdCodeClass.RAW_TEMPERATURE, ErdCodeClass.NON_ZERO_TEMPERATURE]
-            or self.device_class == DEVICE_CLASS_TEMPERATURE
+            or self.device_class == SensorDeviceClass.TEMPERATURE
         ):
             #NOTE: it appears that the API only sets temperature in Fahrenheit,
             #so we'll hard code this UOM instead of using the device configured
             #settings
-            return TEMP_FAHRENHEIT
+            return UnitOfTemperature.FAHRENHEIT
         if (
             self.erd_code_class == ErdCodeClass.BATTERY
-            or self.device_class == DEVICE_CLASS_BATTERY
+            or self.device_class == SensorDeviceClass.BATTERY
         ):
             return "%"
         if self.erd_code_class == ErdCodeClass.PERCENTAGE:
             return "%"
-        if self.device_class == DEVICE_CLASS_POWER_FACTOR:
+        if self.device_class == SensorDeviceClass.POWER_FACTOR:
             return "%"
         if self.erd_code_class == ErdCodeClass.HUMIDITY:
             return "%"
@@ -131,15 +123,15 @@ class GeErdSensor(GeErdEntity, SensorEntity):
             ErdCodeClass.RAW_TEMPERATURE,
             ErdCodeClass.NON_ZERO_TEMPERATURE,
         ]:
-            return DEVICE_CLASS_TEMPERATURE
+            return SensorDeviceClass.TEMPERATURE
         if self.erd_code_class == ErdCodeClass.BATTERY:
-            return DEVICE_CLASS_BATTERY
+            return SensorDeviceClass.BATTERY
         if self.erd_code_class == ErdCodeClass.POWER:
-            return DEVICE_CLASS_POWER
+            return SensorDeviceClass.POWER
         if self.erd_code_class == ErdCodeClass.ENERGY:
-            return DEVICE_CLASS_ENERGY
+            return SensorDeviceClass.ENERGY
         if self.erd_code_class == ErdCodeClass.HUMIDITY:
-            return DEVICE_CLASS_HUMIDITY
+            return SensorDeviceClass.HUMIDITY
 
         return None
 
@@ -147,7 +139,7 @@ class GeErdSensor(GeErdEntity, SensorEntity):
         if self._state_class_override:
             return self._state_class_override
 
-        if self.device_class in [DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_ENERGY]:
+        if self.device_class in [SensorDeviceClass.TEMPERATURE, SensorDeviceClass.ENERGY]:
             return SensorStateClass.MEASUREMENT
         if self.erd_code_class in [ErdCodeClass.FLOW_RATE, ErdCodeClass.PERCENTAGE, ErdCodeClass.HUMIDITY]:
             return SensorStateClass.MEASUREMENT

--- a/custom_components/ge_home/entities/common/ge_water_heater.py
+++ b/custom_components/ge_home/entities/common/ge_water_heater.py
@@ -3,10 +3,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from homeassistant.components.water_heater import WaterHeaterEntity
-from homeassistant.const import (
-    TEMP_FAHRENHEIT,
-    TEMP_CELSIUS
-)
+from homeassistant.const import UnitOfTemperature
 from gehomesdk import ErdCode, ErdMeasurementUnits
 from ...const import DOMAIN
 from .ge_erd_entity import GeEntity
@@ -37,8 +34,8 @@ class GeAbstractWaterHeater(GeEntity, WaterHeaterEntity, metaclass=abc.ABCMeta):
         #It appears that the GE API is alwasy Fehrenheit
         #measurement_system = self.appliance.get_erd_value(ErdCode.TEMPERATURE_UNIT)
         #if measurement_system == ErdMeasurementUnits.METRIC:
-        #    return TEMP_CELSIUS
-        return TEMP_FAHRENHEIT
+        #    return UnitOfTemperature.CELSIUS
+        return UnitOfTemperature.FAHRENHEIT
 
     @property
     def supported_features(self):

--- a/custom_components/ge_home/entities/fridge/const.py
+++ b/custom_components/ge_home/entities/fridge/const.py
@@ -1,10 +1,7 @@
-from homeassistant.components.water_heater import (
-    SUPPORT_OPERATION_MODE,
-    SUPPORT_TARGET_TEMPERATURE
-)
+from homeassistant.components.water_heater import WaterHeaterEntityFeature
 
 ATTR_DOOR_STATUS = "door_status"
-GE_FRIDGE_SUPPORT = (SUPPORT_OPERATION_MODE | SUPPORT_TARGET_TEMPERATURE)
+GE_FRIDGE_SUPPORT = (WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.TARGET_TEMPERATURE)
 
 HEATER_TYPE_FRIDGE = "fridge"
 HEATER_TYPE_FREEZER = "freezer"

--- a/custom_components/ge_home/entities/fridge/convertable_drawer_mode_options.py
+++ b/custom_components/ge_home/entities/fridge/convertable_drawer_mode_options.py
@@ -2,7 +2,7 @@ import logging
 from typing import List, Any, Optional
 
 from gehomesdk import ErdConvertableDrawerMode
-from homeassistant.const import TEMP_FAHRENHEIT
+from homeassistant.const import UnitOfTemperature
 from homeassistant.util.unit_system import UnitSystem
 from ..common import OptionsConverter
 
@@ -43,7 +43,7 @@ class ConvertableDrawerModeOptionsConverter(OptionsConverter):
                 t = _TEMP_MAP.get(value, None)
 
                 if t and self._units.is_metric:
-                    t = self._units.temperature(float(t), TEMP_FAHRENHEIT)
+                    t = self._units.temperature(float(t), UnitOfTemperature.FAHRENHEIT)
                     t = round(t,1)
                 
                 if t:

--- a/custom_components/ge_home/entities/fridge/ge_abstract_fridge.py
+++ b/custom_components/ge_home/entities/fridge/ge_abstract_fridge.py
@@ -6,7 +6,7 @@ import abc
 import logging
 from typing import Any, Dict, List, Optional
 
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_FAHRENHEIT
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.util.unit_conversion import TemperatureConverter
 from gehomesdk import (
     ErdCode,
@@ -117,7 +117,7 @@ class GeAbstractFridge(GeAbstractWaterHeater):
             return getattr(self.setpoint_limits, f"{self.heater_type}_min")
         except:
             _LOGGER.debug("No temperature setpoint limits available. Using hardcoded limits.")
-            return TemperatureConverter.convert(self.temp_limits[f"{self.heater_type}_min"], TEMP_FAHRENHEIT, self.temperature_unit)
+            return TemperatureConverter.convert(self.temp_limits[f"{self.heater_type}_min"], UnitOfTemperature.FAHRENHEIT, self.temperature_unit)
 
     @property
     def max_temp(self):
@@ -126,7 +126,7 @@ class GeAbstractFridge(GeAbstractWaterHeater):
             return getattr(self.setpoint_limits, f"{self.heater_type}_max")
         except:
             _LOGGER.debug("No temperature setpoint limits available. Using hardcoded limits.")
-            return TemperatureConverter.convert(self.temp_limits[f"{self.heater_type}_max"], TEMP_FAHRENHEIT, self.temperature_unit)
+            return TemperatureConverter.convert(self.temp_limits[f"{self.heater_type}_max"], UnitOfTemperature.FAHRENHEIT, self.temperature_unit)
 
     @property
     def current_operation(self) -> str:

--- a/custom_components/ge_home/entities/fridge/ge_dispenser.py
+++ b/custom_components/ge_home/entities/fridge/ge_dispenser.py
@@ -3,7 +3,7 @@
 import logging
 from typing import List, Optional, Dict, Any
 
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_FAHRENHEIT
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from gehomesdk import (
@@ -102,12 +102,12 @@ class GeDispenser(GeAbstractWaterHeater):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return TemperatureConverter.convert(self._min_temp, TEMP_FAHRENHEIT, self.temperature_unit)
+        return TemperatureConverter.convert(self._min_temp, UnitOfTemperature.FAHRENHEIT, self.temperature_unit)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return TemperatureConverter.convert(self._max_temp, TEMP_FAHRENHEIT, self.temperature_unit)
+        return TemperatureConverter.convert(self._max_temp, UnitOfTemperature.FAHRENHEIT, self.temperature_unit)
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:

--- a/custom_components/ge_home/entities/oven/const.py
+++ b/custom_components/ge_home/entities/oven/const.py
@@ -1,13 +1,10 @@
 import bidict
 
-from homeassistant.components.water_heater import (
-    SUPPORT_OPERATION_MODE,
-    SUPPORT_TARGET_TEMPERATURE
-)
+from homeassistant.components.water_heater import WaterHeaterEntityFeature
 from gehomesdk import ErdOvenCookMode
 
 SUPPORT_NONE = 0
-GE_OVEN_SUPPORT = (SUPPORT_OPERATION_MODE | SUPPORT_TARGET_TEMPERATURE)
+GE_OVEN_SUPPORT = (WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.TARGET_TEMPERATURE)
 
 OP_MODE_OFF = "Off"
 OP_MODE_BAKE = "Bake"

--- a/custom_components/ge_home/entities/oven/ge_oven.py
+++ b/custom_components/ge_home/entities/oven/ge_oven.py
@@ -10,7 +10,7 @@ from gehomesdk import (
     OvenCookSetting
 )
 
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from ...const import DOMAIN
 from ...devices import ApplianceApi
 from ..common import GeAbstractWaterHeater
@@ -56,8 +56,8 @@ class GeOven(GeAbstractWaterHeater):
     def temperature_unit(self):
         measurement_system = self.appliance.get_erd_value(ErdCode.TEMPERATURE_UNIT)
         if measurement_system == ErdMeasurementUnits.METRIC:
-            return TEMP_CELSIUS
-        return TEMP_FAHRENHEIT
+            return UnitOfTemperature.CELSIUS
+        return UnitOfTemperature.FAHRENHEIT
 
     @property
     def oven_select(self) -> str:
@@ -155,7 +155,7 @@ class GeOven(GeAbstractWaterHeater):
             target_temp = 0
         elif self.target_temperature:
             target_temp = self.target_temperature
-        elif self.temperature_unit == TEMP_FAHRENHEIT:
+        elif self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             target_temp = 350
         else:
             target_temp = 177

--- a/custom_components/ge_home/entities/water_heater/ge_water_heater.py
+++ b/custom_components/ge_home/entities/water_heater/ge_water_heater.py
@@ -7,12 +7,9 @@ from gehomesdk import (
     ErdWaterHeaterMode
 )
 
-from homeassistant.components.water_heater import (
-    SUPPORT_OPERATION_MODE,
-    SUPPORT_TARGET_TEMPERATURE
-)
+from homeassistant.components.water_heater import WaterHeaterEntityFeature
 
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_FAHRENHEIT
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from ...devices import ApplianceApi
 from ..common import GeAbstractWaterHeater
 from .heater_modes import WhHeaterModeConverter
@@ -34,11 +31,11 @@ class GeWaterHeater(GeAbstractWaterHeater):
 
     @property
     def supported_features(self):
-        return (SUPPORT_OPERATION_MODE | SUPPORT_TARGET_TEMPERATURE)
+        return (WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.TARGET_TEMPERATURE)
 
     @property
     def temperature_unit(self):
-        return TEMP_FAHRENHEIT
+        return UnitOfTemperature.FAHRENHEIT
 
     @property
     def current_temperature(self) -> Optional[int]:


### PR DESCRIPTION
This PR is to update the deprecated constants as of HA 2024.1.0 (https://developers.home-assistant.io/blog/2023/12/19/constant-deprecation/).

This addresses issue #218. 