### PR TITLE
Metric Rounding

### DIFF
--- a/custom_components/ge_home/entities/common/ge_climate.py
+++ b/custom_components/ge_home/entities/common/ge_climate.py
@@ -94,10 +94,20 @@ class GeClimate(GeEntity, ClimateEntity):
 
     @property
     def target_temperature(self) -> Optional[float]:
+        measurement_system = self.appliance.get_erd_value(ErdCode.TEMPERATURE_UNIT)
+        if measurement_system == ErdMeasurementUnits.METRIC:
+            targ = float(self.appliance.get_erd_value(self.target_temperature_erd_code))
+            targ = round( ((targ - 32.0) * (5/9)) / 2 ) * 2 
+            return (9 * targ) / 5 + 32
         return float(self.appliance.get_erd_value(self.target_temperature_erd_code))
 
     @property
     def current_temperature(self) -> Optional[float]:
+        measurement_system = self.appliance.get_erd_value(ErdCode.TEMPERATURE_UNIT)
+        if measurement_system == ErdMeasurementUnits.METRIC:
+            current = float(self.appliance.get_erd_value(self.current_temperature_erd_code))
+            current = round( (current - 32.0) * (5/9)) 
+            return (9 * current) / 5 + 32
         return float(self.appliance.get_erd_value(self.current_temperature_erd_code))
 
     @property


### PR DESCRIPTION
Home assistant rounding messes up metric values when setting and displaying target & current temp, using values like 25.1, 26.3 etc.

This change takes the values and rounds them to their metric counterparts so as to be consistent with the SmartHQ app and the display on the unit itself, showing current temp in .5 intervals and setting in .0 intervals.