### PR TITLE
Fix await async_forward_entry_setup as requested in HA

### DIFF
--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -175,14 +175,12 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
     async def async_setup(self):
         """Setup a new coordinator"""
         _LOGGER.debug("Setting up coordinator")
-
+    
         for component in PLATFORMS:
-            self.hass.async_create_task(
-                self.hass.config_entries.async_forward_entry_setup(
-                    self._config_entry, component
-                )
+            await self.hass.config_entries.async_forward_entry_setup(
+                self._config_entry, component
             )
-
+    
         try:
             await self.async_start_client()
         except (GeNotAuthenticatedError, GeAuthFailedError):
@@ -191,7 +189,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
             raise HaCannotConnect("Cannot connect (server error)")
         except Exception:
             raise HaCannotConnect("Unknown connection failure")
-
+    
         return True
 
     async def async_start_client(self):

--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -175,12 +175,12 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
     async def async_setup(self):
         """Setup a new coordinator"""
         _LOGGER.debug("Setting up coordinator")
-    
+
         for component in PLATFORMS:
             await self.hass.config_entries.async_forward_entry_setup(
                 self._config_entry, component
             )
-    
+
         try:
             await self.async_start_client()
         except (GeNotAuthenticatedError, GeAuthFailedError):
@@ -189,7 +189,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
             raise HaCannotConnect("Cannot connect (server error)")
         except Exception:
             raise HaCannotConnect("Unknown connection failure")
-    
+
         return True
 
     async def async_start_client(self):


### PR DESCRIPTION
Detected code that calls async_forward_entry_setup for integration ge_home during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1. Please report this issue.

By adding await before self.hass.config_entries.async_forward_entry_setup, you ensure that the call is properly awaited, preventing the setup lock issue.