### PR TITLE
Set "Could not find appliance % in known device list." to INFO

### DIFF
--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -285,7 +285,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
         try:
             api = self.appliance_apis[appliance.mac_addr]
         except KeyError:
-            _LOGGER.warn(f"Could not find appliance {appliance.mac_addr} in known device list.")
+            _LOGGER.info(f"Could not find appliance {appliance.mac_addr} in known device list.")
             return
         
         self._update_entity_state(api.entities)


### PR DESCRIPTION
Changed log level to INFO since known device list is deprecated.

https://github.com/simbaja/ha_gehome/issues/237

I'll try to find time later this week to read up on the 'device registry index' and see if it makes sense to add the appliances there.