### PR TITLE
Bump gehomesdk to allow specifying ssl_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # GE Home Appliances (SmartHQ) Changelog
 
+## 0.6.12
+
+- Bugfix: Deprecations [#271]
+
 ## 0.6.11
 
 - Bugfix: Fixed convertable drawer issue [#243]

--- a/custom_components/ge_home/manifest.json
+++ b/custom_components/ge_home/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/simbaja/ha_gehome",
   "requirements": ["gehomesdk==0.5.28","magicattr==0.1.6","slixmpp==1.8.3"],
   "codeowners": ["@simbaja"],	
-  "version": "0.6.11"
+  "version": "0.6.12"
 }

--- a/custom_components/ge_home/manifest.json
+++ b/custom_components/ge_home/manifest.json
@@ -5,7 +5,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "documentation": "https://github.com/simbaja/ha_gehome",
-  "requirements": ["gehomesdk==0.5.28","magicattr==0.1.6","slixmpp==1.8.3"],
+  "requirements": ["gehomesdk==0.5.29","magicattr==0.1.6","slixmpp==1.8.3"],
   "codeowners": ["@simbaja"],	
-  "version": "0.6.12"
+  "version": "0.6.13"
 }

--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -175,14 +175,12 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
     async def async_setup(self):
         """Setup a new coordinator"""
         _LOGGER.debug("Setting up coordinator")
-
+    
         for component in PLATFORMS:
-            self.hass.async_create_task(
-                self.hass.config_entries.async_forward_entry_setup(
-                    self._config_entry, component
-                )
+            await self.hass.config_entries.async_forward_entry_setup(
+                self._config_entry, component
             )
-
+    
         try:
             await self.async_start_client()
         except (GeNotAuthenticatedError, GeAuthFailedError):
@@ -191,7 +189,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
             raise HaCannotConnect("Cannot connect (server error)")
         except Exception:
             raise HaCannotConnect("Unknown connection failure")
-
+    
         return True
 
     async def async_start_client(self):

--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import get_default_context 
 from .const import (
     DOMAIN,
     EVENT_ALL_APPLIANCES_READY,
@@ -93,6 +94,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
             self._password,
             self._region,
             event_loop=event_loop,
+            ssl_context=get_default_context(),
         )
         client.add_event_handler(EVENT_APPLIANCE_INITIAL_UPDATE, self.on_device_initial_update)
         client.add_event_handler(EVENT_APPLIANCE_UPDATE_RECEIVED, self.on_device_update)

--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -175,12 +175,12 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
     async def async_setup(self):
         """Setup a new coordinator"""
         _LOGGER.debug("Setting up coordinator")
-    
+
         for component in PLATFORMS:
             await self.hass.config_entries.async_forward_entry_setup(
                 self._config_entry, component
             )
-    
+
         try:
             await self.async_start_client()
         except (GeNotAuthenticatedError, GeAuthFailedError):
@@ -189,7 +189,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
             raise HaCannotConnect("Cannot connect (server error)")
         except Exception:
             raise HaCannotConnect("Unknown connection failure")
-    
+
         return True
 
     async def async_start_client(self):


### PR DESCRIPTION
Bump gehomesdk from https://github.com/simbaja/gehome/pull/74 to fix https://github.com/simbaja/gehome/issues/73 by using the default HA ssl context.