### PR TITLE
Add in Active and Boost mode on/off for Haier Heatpump hot water cylinder

### DIFF
--- a/custom_components/ge_home/config_flow.py
+++ b/custom_components/ge_home/config_flow.py
@@ -8,9 +8,9 @@ import asyncio
 import async_timeout
 
 from gehomesdk import (
-    GeAuthFailedError, 
-    GeNotAuthenticatedError, 
-    GeGeneralServerError, 
+    GeAuthFailedError,
+    GeNotAuthenticatedError,
+    GeGeneralServerError,
     async_get_oauth2_token,
     LOGIN_REGIONS
 )
@@ -19,6 +19,9 @@ import voluptuous as vol
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_REGION
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
 from .const import DOMAIN  # pylint:disable=unused-import
 from .exceptions import HaAuthError, HaCannotConnect, HaAlreadyConfigured
 
@@ -26,7 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 
 GEHOME_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_USERNAME): str, 
+        vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
         vol.Required(CONF_REGION): vol.In(LOGIN_REGIONS.keys())
     }
@@ -35,7 +38,7 @@ GEHOME_SCHEMA = vol.Schema(
 async def validate_input(hass: core.HomeAssistant, data):
     """Validate the user input allows us to connect."""
 
-    session = hass.helpers.aiohttp_client.async_get_clientsession(hass)
+    session = async_get_clientsession(hass)
 
     # noinspection PyBroadException
     try:
@@ -72,7 +75,7 @@ class GeHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except HaCannotConnect:
                 errors["base"] = "cannot_connect"
             except HaAuthError:
-                errors["base"] = "invalid_auth"      
+                errors["base"] = "invalid_auth"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -85,7 +88,7 @@ class GeHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }
         _LOGGER.debug(f"Existing accounts: {existing_accounts}")
         if username in existing_accounts:
-            raise HaAlreadyConfigured  
+            raise HaAlreadyConfigured
 
     async def async_step_user(self, user_input: Optional[Dict] = None):
         """Handle the initial step."""

--- a/custom_components/ge_home/devices/water_heater.py
+++ b/custom_components/ge_home/devices/water_heater.py
@@ -18,6 +18,7 @@ from ..entities import (
     GeErdSwitch, 
     ErdOnOffBoolConverter
 )
+
 from ..entities.water_heater.boost_mode import GeWaterHeaterBoostModeSwitch
 from ..entities.water_heater.active_mode import GeWaterHeaterActiveModeSwitch
 

--- a/custom_components/ge_home/devices/water_heater.py
+++ b/custom_components/ge_home/devices/water_heater.py
@@ -18,6 +18,8 @@ from ..entities import (
     GeErdSwitch, 
     ErdOnOffBoolConverter
 )
+from ..entities.water_heater.boost_mode import GeWaterHeaterBoostModeSwitch
+from ..entities.water_heater.active_mode import GeWaterHeaterActiveModeSwitch
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +39,13 @@ class WaterHeaterApi(ApplianceApi):
             GeErdSensor(self, ErdCode.WH_HEATER_VACATION_MODE_MAX_TIME),
             GeWaterHeater(self)
         ]
+        
+        # Add boost mode switch
+        from ..entities.water_heater.boost_mode import GeWaterHeaterBoostModeSwitch
+        wh_entities.append(GeWaterHeaterBoostModeSwitch(self))
+        # Add active mode switch
+        from ..entities.water_heater.active_mode import GeWaterHeaterActiveModeSwitch
+        wh_entities.append(GeWaterHeaterActiveModeSwitch(self))
 
         entities = base_entities + wh_entities
         return entities
-        

--- a/custom_components/ge_home/entities/water_heater/__init__.py
+++ b/custom_components/ge_home/entities/water_heater/__init__.py
@@ -1,2 +1,4 @@
 from .heater_modes import WhHeaterModeConverter
 from .ge_water_heater import GeWaterHeater
+from .active_mode import GeWaterHeaterActiveModeSwitch
+from .boost_mode import GeWaterHeaterBoostModeSwitch

--- a/custom_components/ge_home/entities/water_heater/active_mode.py
+++ b/custom_components/ge_home/entities/water_heater/active_mode.py
@@ -1,0 +1,50 @@
+import logging
+from typing import Any
+
+from gehomesdk import ErdCodeType, ErdCode, ErdOnOff, ErdWaterHeaterActiveState
+from ...devices import ApplianceApi
+from ..common import GeErdSwitch, BoolConverter
+
+_LOGGER = logging.getLogger(__name__)
+
+class WaterHeaterActiveModeBoolConverter(BoolConverter):
+    def boolify(self, value: ErdWaterHeaterActiveState) -> bool:
+        # Convert ErdWaterHeaterActiveState to bool
+        return value == ErdWaterHeaterActiveState.ENABLED
+    
+    def true_value(self) -> Any:
+        return ErdWaterHeaterActiveState.ENABLED
+    
+    def false_value(self) -> Any:
+        return ErdWaterHeaterActiveState.DISABLED
+
+class GeWaterHeaterActiveModeSwitch(GeErdSwitch):
+    """Switch to control the water heater Active mode"""
+
+    def __init__(self, api: ApplianceApi):
+        super().__init__(
+            api, 
+            ErdCode.WH_HEATER_ACTIVE_STATE, 
+            WaterHeaterActiveModeBoolConverter(), 
+            icon_on_override="mdi:rocket-launch", 
+            icon_off_override="mdi:rocket-launch-outline"
+        )
+        self._attr_name = "Active Mode"
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if Active mode is on."""
+        # Use the read-only ERD to get the current state
+        return self._converter.boolify(self.appliance.get_erd_value(ErdCode.WH_HEATER_ACTIVE_STATE))
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the Active mode on."""
+        _LOGGER.debug(f"Turning on Active mode for {self.unique_id}")
+        # Use the write ERD to set the state
+        await self.appliance.async_set_erd_value(ErdCode.WH_HEATER_ACTIVE_CONTROL, self._converter.true_value())
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the Active mode off."""
+        _LOGGER.debug(f"Turning off Active mode for {self.unique_id}")
+        # Use the write ERD to set the state
+        await self.appliance.async_set_erd_value(ErdCode.WH_HEATER_ACTIVE_CONTROL, self._converter.false_value())

--- a/custom_components/ge_home/entities/water_heater/active_mode.py
+++ b/custom_components/ge_home/entities/water_heater/active_mode.py
@@ -13,7 +13,7 @@ class WaterHeaterActiveModeBoolConverter(BoolConverter):
         return value == ErdWaterHeaterActiveState.ON
     
     def true_value(self) -> Any:
-        return ErdWaterHeaterActiveState.OFF
+        return ErdWaterHeaterActiveState.ON
     
     def false_value(self) -> Any:
         return ErdWaterHeaterActiveState.OFF

--- a/custom_components/ge_home/entities/water_heater/active_mode.py
+++ b/custom_components/ge_home/entities/water_heater/active_mode.py
@@ -10,13 +10,13 @@ _LOGGER = logging.getLogger(__name__)
 class WaterHeaterActiveModeBoolConverter(BoolConverter):
     def boolify(self, value: ErdWaterHeaterActiveState) -> bool:
         # Convert ErdWaterHeaterActiveState to bool
-        return value == ErdWaterHeaterActiveState.ENABLED
+        return value == ErdWaterHeaterActiveState.ON
     
     def true_value(self) -> Any:
-        return ErdWaterHeaterActiveState.ENABLED
+        return ErdWaterHeaterActiveState.OFF
     
     def false_value(self) -> Any:
-        return ErdWaterHeaterActiveState.DISABLED
+        return ErdWaterHeaterActiveState.OFF
 
 class GeWaterHeaterActiveModeSwitch(GeErdSwitch):
     """Switch to control the water heater Active mode"""
@@ -26,8 +26,8 @@ class GeWaterHeaterActiveModeSwitch(GeErdSwitch):
             api, 
             ErdCode.WH_HEATER_ACTIVE_STATE, 
             WaterHeaterActiveModeBoolConverter(), 
-            icon_on_override="mdi:rocket-launch", 
-            icon_off_override="mdi:rocket-launch-outline"
+            icon_on_override="mdi:power", 
+            icon_off_override="mdi:power-standby"
         )
         self._attr_name = "Active Mode"
 

--- a/custom_components/ge_home/entities/water_heater/boost_mode.py
+++ b/custom_components/ge_home/entities/water_heater/boost_mode.py
@@ -1,0 +1,50 @@
+import logging
+from typing import Any
+
+from gehomesdk import ErdCodeType, ErdCode, ErdOnOff, ErdWaterHeaterBoostState
+from ...devices import ApplianceApi
+from ..common import GeErdSwitch, BoolConverter
+
+_LOGGER = logging.getLogger(__name__)
+
+class WaterHeaterBoostModeBoolConverter(BoolConverter):
+    def boolify(self, value: ErdWaterHeaterBoostState) -> bool:
+        # Convert ErdWaterHeaterBoostState to bool
+        return value == ErdWaterHeaterBoostState.ENABLED
+    
+    def true_value(self) -> Any:
+        return ErdWaterHeaterBoostState.ENABLED
+    
+    def false_value(self) -> Any:
+        return ErdWaterHeaterBoostState.DISABLED
+
+class GeWaterHeaterBoostModeSwitch(GeErdSwitch):
+    """Switch to control the water heater boost mode"""
+
+    def __init__(self, api: ApplianceApi):
+        super().__init__(
+            api, 
+            ErdCode.WH_HEATER_BOOST_STATE, 
+            WaterHeaterBoostModeBoolConverter(), 
+            icon_on_override="mdi:rocket-launch", 
+            icon_off_override="mdi:rocket-launch-outline"
+        )
+        self._attr_name = "Boost Mode"
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if boost mode is on."""
+        # Use the read-only ERD to get the current state
+        return self._converter.boolify(self.appliance.get_erd_value(ErdCode.WH_HEATER_BOOST_STATE))
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the boost mode on."""
+        _LOGGER.debug(f"Turning on boost mode for {self.unique_id}")
+        # Use the write ERD to set the state
+        await self.appliance.async_set_erd_value(ErdCode.WH_HEATER_BOOST_CONTROL, self._converter.true_value())
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the boost mode off."""
+        _LOGGER.debug(f"Turning off boost mode for {self.unique_id}")
+        # Use the write ERD to set the state
+        await self.appliance.async_set_erd_value(ErdCode.WH_HEATER_BOOST_CONTROL, self._converter.false_value())

--- a/custom_components/ge_home/entities/water_heater/boost_mode.py
+++ b/custom_components/ge_home/entities/water_heater/boost_mode.py
@@ -10,13 +10,13 @@ _LOGGER = logging.getLogger(__name__)
 class WaterHeaterBoostModeBoolConverter(BoolConverter):
     def boolify(self, value: ErdWaterHeaterBoostState) -> bool:
         # Convert ErdWaterHeaterBoostState to bool
-        return value == ErdWaterHeaterBoostState.ENABLED
+        return value == ErdWaterHeaterBoostState.ON
     
     def true_value(self) -> Any:
-        return ErdWaterHeaterBoostState.ENABLED
+        return ErdWaterHeaterBoostState.ON
     
     def false_value(self) -> Any:
-        return ErdWaterHeaterBoostState.DISABLED
+        return ErdWaterHeaterBoostState.OFF
 
 class GeWaterHeaterBoostModeSwitch(GeErdSwitch):
     """Switch to control the water heater boost mode"""

--- a/custom_components/ge_home/entities/water_heater/heater_modes.py
+++ b/custom_components/ge_home/entities/water_heater/heater_modes.py
@@ -15,7 +15,7 @@ class WhHeaterModeConverter(OptionsConverter):
         try:
             return ErdWaterHeaterMode[enum_val]
         except:
-            _LOGGER.warning(f"Could not heater mode to {enum_val}")
+            _LOGGER.warning(f"Could not convert heater mode to {enum_val}")
             return ErdWaterHeaterMode.UNKNOWN
     def to_option_string(self, value: ErdWaterHeaterMode) -> Optional[str]:
         try:


### PR DESCRIPTION
Add boost and active mode switches for Haier Heatpump water heater control.

Some code AI Generated Using Cline anthropic/claude-3-7-sonnet-latest and Copilot.