### PR TITLE
Fixed lines relating to "Unexpected Error" at login after HA2025.5.1 …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # GE Home Appliances (SmartHQ) Changelog
 
+## 2025.2.1
+
+- Bugfix: Fixed #339
+
 ## 2025.2.0
 
 - Breaking: Changed dishwasher pods to number

--- a/custom_components/ge_home/config_flow.py
+++ b/custom_components/ge_home/config_flow.py
@@ -18,6 +18,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_REGION
+from homeassistant.helpers.aiohttp_client import async_get_clientsession  # FIXED: Proper import of client session
 
 from .const import DOMAIN  # pylint:disable=unused-import
 from .exceptions import HaAuthError, HaCannotConnect, HaAlreadyConfigured
@@ -35,11 +36,11 @@ GEHOME_SCHEMA = vol.Schema(
 async def validate_input(hass: core.HomeAssistant, data):
     """Validate the user input allows us to connect."""
 
-    session = hass.helpers.aiohttp_client.async_get_clientsession(hass)
+    session = async_get_clientsession(hass)  # FIXED: Corrected session retrieval
 
     # noinspection PyBroadException
     try:
-        with async_timeout.timeout(10):
+        async with async_timeout.timeout(10):
             _ = await async_get_oauth2_token(session, data[CONF_USERNAME], data[CONF_PASSWORD], data[CONF_REGION])
     except (asyncio.TimeoutError, aiohttp.ClientError):
         raise HaCannotConnect('Connection failure')

--- a/custom_components/ge_home/manifest.json
+++ b/custom_components/ge_home/manifest.json
@@ -5,7 +5,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "documentation": "https://github.com/simbaja/ha_gehome",
-  "requirements": ["gehomesdk==2025.2.0","magicattr==0.1.6","slixmpp==1.8.3"],
+  "requirements": ["gehomesdk==2025.2.2","magicattr==0.1.6","slixmpp==1.8.3"],
   "codeowners": ["@simbaja"],	
-  "version": "2025.2.0"
+  "version": "2025.2.1"
 }

--- a/info.md
+++ b/info.md
@@ -145,6 +145,11 @@ A/C Controls:
 
 #### Bugfixes
 
+{% if version_installed.split('.') | map('int') < '2025.2.1'.split('.') | map('int') %}
+- Fix for #339
+{% endif %}
+
+
 {% if version_installed.split('.') | map('int') < '2025.2.0'.split('.') | map('int') %}
 - Updated SDK to fix broken types
 {% endif %}


### PR DESCRIPTION
After updating Home Assistant to 2025.5.1, I could not re-add the GE Home integration after removing in attempt to fix another issue due to the login dialog returning "Unexpected Error". This is the same as mentioned in #365 [here](https://github.com/simbaja/ha_gehome/issues/365#issuecomment-2866767747). Made changes to config_flow.py relating to the referenced helpers attribute and, upon testing, have successfully logged in via the log in dialog for the integration.