### PR TITLE
Use `duration` device class for timers

### DIFF
--- a/custom_components/ge_home/devices/washer.py
+++ b/custom_components/ge_home/devices/washer.py
@@ -28,13 +28,13 @@ class WasherApi(ApplianceApi):
             GeErdBinarySensor(self, ErdCode.LAUNDRY_REMOTE_STATUS),
         ]
 
-        washer_entities = self.get_washer_entities()      
+        washer_entities = self.get_washer_entities()
 
         entities = base_entities + common_entities + washer_entities
         return entities
-        
+
     def get_washer_entities(self) -> List[Entity]:
-        washer_entities = [         
+        washer_entities = [
             GeErdSensor(self, ErdCode.LAUNDRY_WASHER_SOIL_LEVEL, icon_override="mdi:emoticon-poop"),
             GeErdSensor(self, ErdCode.LAUNDRY_WASHER_WASHTEMP_LEVEL),
             GeErdSensor(self, ErdCode.LAUNDRY_WASHER_SPINTIME_LEVEL, icon_override="mdi:speedometer"),
@@ -44,7 +44,7 @@ class WasherApi(ApplianceApi):
         if self.has_erd_code(ErdCode.LAUNDRY_WASHER_DOOR_LOCK):
             washer_entities.extend([GeErdBinarySensor(self, ErdCode.LAUNDRY_WASHER_DOOR_LOCK)])
         if self.has_erd_code(ErdCode.LAUNDRY_WASHER_TANK_STATUS):
-            washer_entities.extend([GeErdSensor(self, ErdCode.LAUNDRY_WASHER_TANK_STATUS)])           
+            washer_entities.extend([GeErdSensor(self, ErdCode.LAUNDRY_WASHER_TANK_STATUS)])
         if self.has_erd_code(ErdCode.LAUNDRY_WASHER_TANK_SELECTED):
             washer_entities.extend([GeErdSensor(self, ErdCode.LAUNDRY_WASHER_TANK_SELECTED)])
         if self.has_erd_code(ErdCode.LAUNDRY_WASHER_TIMESAVER):

--- a/custom_components/ge_home/devices/washer.py
+++ b/custom_components/ge_home/devices/washer.py
@@ -22,8 +22,8 @@ class WasherApi(ApplianceApi):
             GeErdSensor(self, ErdCode.LAUNDRY_CYCLE, icon_override="mdi:state-machine"),
             GeErdSensor(self, ErdCode.LAUNDRY_SUB_CYCLE, icon_override="mdi:state-machine"),
             GeErdBinarySensor(self, ErdCode.LAUNDRY_END_OF_CYCLE),
-            GeErdSensor(self, ErdCode.LAUNDRY_TIME_REMAINING),
-            GeErdSensor(self, ErdCode.LAUNDRY_DELAY_TIME_REMAINING),
+            GeErdSensor(self, ErdCode.LAUNDRY_TIME_REMAINING, suggested_uom="min"),
+            GeErdSensor(self, ErdCode.LAUNDRY_DELAY_TIME_REMAINING, suggested_uom="h"),
             GeErdBinarySensor(self, ErdCode.LAUNDRY_DOOR),
             GeErdBinarySensor(self, ErdCode.LAUNDRY_REMOTE_STATUS),
         ]

--- a/custom_components/ge_home/entities/common/ge_erd_number.py
+++ b/custom_components/ge_home/entities/common/ge_erd_number.py
@@ -16,11 +16,11 @@ class GeErdNumber(GeErdEntity, NumberEntity):
     """GE Entity for numbers"""
 
     def __init__(
-        self, 
-        api: ApplianceApi, 
-        erd_code: ErdCodeType, 
-        erd_override: str = None, 
-        icon_override: str = None, 
+        self,
+        api: ApplianceApi,
+        erd_code: ErdCodeType,
+        erd_override: str = None,
+        icon_override: str = None,
         device_class_override: str = None,
         uom_override: str = None,
         data_type_override: ErdDataType = None,

--- a/custom_components/ge_home/entities/common/ge_erd_sensor.py
+++ b/custom_components/ge_home/entities/common/ge_erd_sensor.py
@@ -23,12 +23,16 @@ class GeErdSensor(GeErdEntity, SensorEntity):
         device_class_override: str = None,
         state_class_override: str = None,
         uom_override: str = None,
-        data_type_override: ErdDataType = None
+        data_type_override: ErdDataType = None,
+        suggested_uom: str = None,
+        suggested_precision: int = None
     ):
         super().__init__(api, erd_code, erd_override, icon_override, device_class_override)
         self._uom_override = uom_override
         self._state_class_override = state_class_override
         self._data_type_override = data_type_override
+        self._suggested_uom = suggested_uom
+        self._suggested_precision = suggested_precision
 
     @property
     def native_value(self):
@@ -52,6 +56,14 @@ class GeErdSensor(GeErdEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self) -> Optional[str]:
         return self._get_uom()
+
+    @property
+    def suggested_unit_of_measurement(self) -> Optional[str]:
+        return self._suggested_uom
+
+    @property
+    def suggested_precision(self) -> Optional[int]:
+        return self._suggested_precision
 
     @property
     def state_class(self) -> Optional[str]:

--- a/custom_components/ge_home/entities/common/ge_erd_sensor.py
+++ b/custom_components/ge_home/entities/common/ge_erd_sensor.py
@@ -14,11 +14,11 @@ class GeErdSensor(GeErdEntity, SensorEntity):
     """GE Entity for sensors"""
 
     def __init__(
-        self, 
-        api: ApplianceApi, 
-        erd_code: ErdCodeType, 
-        erd_override: str = None, 
-        icon_override: str = None, 
+        self,
+        api: ApplianceApi,
+        erd_code: ErdCodeType,
+        erd_override: str = None,
+        icon_override: str = None,
         device_class_override: str = None,
         state_class_override: str = None,
         uom_override: str = None,
@@ -34,7 +34,7 @@ class GeErdSensor(GeErdEntity, SensorEntity):
         try:
             value = self.appliance.get_erd_value(self.erd_code)
 
-            # if it's a numeric data type, return it directly            
+            # if it's a numeric data type, return it directly
             if self._data_type in [ErdDataType.INT, ErdDataType.FLOAT]:
                 return self._convert_numeric_value_from_device(value)
 
@@ -81,7 +81,7 @@ class GeErdSensor(GeErdEntity, SensorEntity):
 
     def _get_uom(self):
         """Select appropriate units"""
-        
+
         #if we have an override, just use it
         if self._uom_override:
             return self._uom_override
@@ -109,8 +109,8 @@ class GeErdSensor(GeErdEntity, SensorEntity):
         if self.erd_code_class == ErdCodeClass.FLOW_RATE:
             #if self._measurement_system == ErdMeasurementUnits.METRIC:
             #    return "lpm"
-            return "gpm" 
-        if self.erd_code_class == ErdCodeClass.LIQUID_VOLUME:       
+            return "gpm"
+        if self.erd_code_class == ErdCodeClass.LIQUID_VOLUME:
             #if self._measurement_system == ErdMeasurementUnits.METRIC:
             #    return "l"
             return "gal"
@@ -145,7 +145,7 @@ class GeErdSensor(GeErdEntity, SensorEntity):
             return SensorStateClass.MEASUREMENT
         if self.erd_code_class in [ErdCodeClass.LIQUID_VOLUME]:
             return SensorStateClass.TOTAL_INCREASING
-        
+
         return None
 
     def _get_icon(self):
@@ -159,6 +159,6 @@ class GeErdSensor(GeErdEntity, SensorEntity):
     async def set_value(self, value):
         """Sets the ERD value, assumes that the data type is correct"""
         try:
-            await self.appliance.async_set_erd_value(self.erd_code, value) 
+            await self.appliance.async_set_erd_value(self.erd_code, value)
         except:
             _LOGGER.warning(f"Could not set {self.name} to {value}")

--- a/custom_components/ge_home/entities/dehumidifier/dehumidifier_fan_speed_sensor.py
+++ b/custom_components/ge_home/entities/dehumidifier/dehumidifier_fan_speed_sensor.py
@@ -5,22 +5,22 @@ from gehomesdk import ErdCodeType, ErdCodeClass, ErdDataType, ErdAcFanSetting
 
 class GeDehumidifierFanSpeedSensor(GeErdSensor):
     def __init__(
-        self, 
-        api: ApplianceApi, 
-        erd_code: ErdCodeType, 
-        erd_override: str = None, 
-        icon_override: str = None, 
+        self,
+        api: ApplianceApi,
+        erd_code: ErdCodeType,
+        erd_override: str = None,
+        icon_override: str = None,
         device_class_override: str = None,
         state_class_override: str = None,
         uom_override: str = None,
         data_type_override: ErdDataType = None
     ):
-    
+
         super().__init__(
-            api, 
-            erd_code, 
-            erd_override, 
-            icon_override, 
+            api,
+            erd_code,
+            erd_override,
+            icon_override,
             device_class_override,
             state_class_override,
             uom_override,
@@ -36,5 +36,3 @@ class GeDehumidifierFanSpeedSensor(GeErdSensor):
             return self._converter.to_option_string(value)
         except KeyError:
             return None
-
-    


### PR DESCRIPTION
- Uses the `duration` device class for timer code class (fixes #312)
- Adds `suggested_unit_of_measurement` and `suggested_display_precision` properties to improve initial display in the UI
  - I've only set them for laundry timers