### PR TITLE
Heat uses a separate ERD code for temperature

### DIFF
--- a/custom_components/ge_home/entities/ac/ge_pac_climate.py
+++ b/custom_components/ge_home/entities/ac/ge_pac_climate.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, List, Optional
 
 from homeassistant.components.climate import HVACMode
-from gehomesdk import ErdCode, ErdAcOperationMode, ErdSacAvailableModes, ErdSacTargetTemperatureRange
+from gehomesdk import ErdCode, ErdAcOperationMode, ErdAcAvailableModes, ErdSacTargetTemperatureRange
 from ...devices import ApplianceApi
 from ..common import GeClimate, OptionsConverter
 from .fan_mode_options import AcFanOnlyFanModeOptionsConverter
@@ -10,7 +10,7 @@ from .fan_mode_options import AcFanOnlyFanModeOptionsConverter
 _LOGGER = logging.getLogger(__name__)
 
 class PacHvacModeOptionsConverter(OptionsConverter):
-    def __init__(self, available_modes: ErdSacAvailableModes):
+    def __init__(self, available_modes: ErdAcAvailableModes):
         self._available_modes = available_modes
 
     @property
@@ -51,7 +51,7 @@ class GePacClimate(GeClimate):
         super().__init__(api, None, AcFanOnlyFanModeOptionsConverter(), AcFanOnlyFanModeOptionsConverter())
 
         #get a couple ERDs that shouldn't change if available
-        self._modes: ErdSacAvailableModes = self.api.try_get_erd_value(ErdCode.SAC_AVAILABLE_MODES)
+        self._modes: ErdAcAvailableModes = self.api.try_get_erd_value(ErdCode.AC_AVAILABLE_MODES)
         self._temp_range: ErdSacTargetTemperatureRange = self.api.try_get_erd_value(ErdCode.SAC_TARGET_TEMPERATURE_RANGE)
         #construct the converter based on the available modes
         self._hvac_mode_converter = PacHvacModeOptionsConverter(self._modes)

--- a/custom_components/ge_home/entities/ac/ge_sac_climate.py
+++ b/custom_components/ge_home/entities/ac/ge_sac_climate.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, List, Optional
 
 from homeassistant.components.climate import HVACMode
-from gehomesdk import ErdCode, ErdAcOperationMode, ErdSacAvailableModes, ErdSacTargetTemperatureRange
+from gehomesdk import ErdCode, ErdAcOperationMode, ErdAcAvailableModes, ErdSacTargetTemperatureRange
 from ...devices import ApplianceApi
 from ..common import GeClimate, OptionsConverter
 from .fan_mode_options import AcFanOnlyFanModeOptionsConverter, AcFanModeOptionsConverter
@@ -10,7 +10,7 @@ from .fan_mode_options import AcFanOnlyFanModeOptionsConverter, AcFanModeOptions
 _LOGGER = logging.getLogger(__name__)
 
 class SacHvacModeOptionsConverter(OptionsConverter):
-    def __init__(self, available_modes: ErdSacAvailableModes):
+    def __init__(self, available_modes: ErdAcAvailableModes):
         self._available_modes = available_modes
 
     @property
@@ -55,7 +55,7 @@ class GeSacClimate(GeClimate):
         super().__init__(api, None, AcFanModeOptionsConverter(), AcFanOnlyFanModeOptionsConverter())
 
         #get a couple ERDs that shouldn't change if available
-        self._modes: ErdSacAvailableModes = self.api.try_get_erd_value(ErdCode.SAC_AVAILABLE_MODES)
+        self._modes: ErdAcAvailableModes = self.api.try_get_erd_value(ErdCode.AC_AVAILABLE_MODES)
         self._temp_range: ErdSacTargetTemperatureRange = self.api.try_get_erd_value(ErdCode.SAC_TARGET_TEMPERATURE_RANGE)
         #construct the converter based on the available modes
         self._hvac_mode_converter = SacHvacModeOptionsConverter(self._modes)

--- a/custom_components/ge_home/entities/ac/ge_wac_climate.py
+++ b/custom_components/ge_home/entities/ac/ge_wac_climate.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, List, Optional
 
 from homeassistant.components.climate import HVACMode
-from gehomesdk import ErdAcOperationMode, ErdCode, ErdSacAvailableModes
+from gehomesdk import ErdAcOperationMode, ErdCode, ErdAcAvailableModes
 from ...devices import ApplianceApi
 from ..common import GeClimate, OptionsConverter
 from .fan_mode_options import AcFanModeOptionsConverter, AcFanOnlyFanModeOptionsConverter
@@ -10,7 +10,7 @@ from .fan_mode_options import AcFanModeOptionsConverter, AcFanOnlyFanModeOptions
 _LOGGER = logging.getLogger(__name__)
 
 class WacHvacModeOptionsConverter(OptionsConverter):
-    def __init__(self, available_modes: ErdSacAvailableModes):
+    def __init__(self, available_modes: ErdAcAvailableModes):
         self._available_modes = available_modes
 
     @property
@@ -47,5 +47,5 @@ class WacHvacModeOptionsConverter(OptionsConverter):
 class GeWacClimate(GeClimate):
     """Class for Window AC units"""
     def __init__(self, api: ApplianceApi):
-        available_modes = api.try_get_erd_value(ErdCode.SAC_AVAILABLE_MODES)
+        available_modes = api.try_get_erd_value(ErdCode.AC_AVAILABLE_MODES)
         super().__init__(api, WacHvacModeOptionsConverter(available_modes), AcFanModeOptionsConverter(), AcFanOnlyFanModeOptionsConverter())

--- a/custom_components/ge_home/entities/common/ge_climate.py
+++ b/custom_components/ge_home/entities/common/ge_climate.py
@@ -36,7 +36,8 @@ class GeClimate(GeEntity, ClimateEntity):
         current_temperature_erd_code: ErdCodeType = ErdCode.AC_AMBIENT_TEMPERATURE,
         target_temperature_erd_code: ErdCodeType = ErdCode.AC_TARGET_TEMPERATURE,
         hvac_mode_erd_code: ErdCodeType = ErdCode.AC_OPERATION_MODE,
-        fan_mode_erd_code: ErdCodeType = ErdCode.AC_FAN_SETTING
+        fan_mode_erd_code: ErdCodeType = ErdCode.AC_FAN_SETTING,
+        target_heating_temperature_erd_code: ErdCodeType = ErdCode.AC_TARGET_HEATING_TEMPERATURE,
 
     ):
         super().__init__(api)
@@ -51,6 +52,7 @@ class GeClimate(GeEntity, ClimateEntity):
         self._target_temperature_erd_code = api.appliance.translate_erd_code(target_temperature_erd_code)
         self._hvac_mode_erd_code = api.appliance.translate_erd_code(hvac_mode_erd_code)
         self._fan_mode_erd_code = api.appliance.translate_erd_code(fan_mode_erd_code)
+        self._target_heating_temperature_erd_code = api.appliance.translate_erd_code(target_heating_temperature_erd_code)
 
     @property
     def unique_id(self) -> str:
@@ -66,6 +68,8 @@ class GeClimate(GeEntity, ClimateEntity):
 
     @property
     def target_temperature_erd_code(self):
+        if self.hvac_mode == HVACMode.HEAT:
+            return self._target_heating_temperature_erd_code
         return self._target_temperature_erd_code
 
     @property

--- a/custom_components/ge_home/manifest.json
+++ b/custom_components/ge_home/manifest.json
@@ -5,7 +5,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "documentation": "https://github.com/simbaja/ha_gehome",
-  "requirements": ["gehomesdk==2025.5.0","magicattr==0.1.6","slixmpp==1.8.3"],
+  "requirements": ["gehomesdk==2025.6.0","magicattr==0.1.6","slixmpp==1.8.3"],
   "codeowners": ["@simbaja"],	
   "version": "2025.7.0"
 }


### PR DESCRIPTION
Also, sync up with heat-related updates to gehomesdk - depends on [gehomesdk 2025.6.0](https://github.com/simbaja/gehome/pull/96).