### PR TITLE
Avoid returning None for oven target_temperature

### DIFF
--- a/custom_components/ge_home/entities/oven/ge_oven.py
+++ b/custom_components/ge_home/entities/oven/ge_oven.py
@@ -136,7 +136,7 @@ class GeOven(GeAbstractWaterHeater):
         cook_mode = self.current_cook_setting
         if cook_mode.temperature:
             return cook_mode.temperature
-        return None
+        return 0.0
 
     @property
     def min_temp(self) -> int:


### PR DESCRIPTION
When the oven is off, current_cook_setting.temperature may be None. This causes target_temperature to return None, which breaks downstream consumers that expect a numeric value (e.g. Google Assistant device state serialization).

Return a valid numeric temperature instead of None so the oven entity always exposes a stable target_temperature value.

This prevents Google Assistant queries from failing with: TypeError: float() argument must be a string or a real number, not 'NoneType'