### PR TITLE
Fix: Persist ApplianceApis on reconnect to prevent duplicate entities

### DIFF
--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -163,6 +163,9 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
         for c in self._signal_remove_callbacks:
             c()
         self._signal_remove_callbacks.clear()
+        
+        # clear the appliances (moved from _reset_sync_state to ensure proper cleanup on unload)
+        self._appliance_apis.clear()
 
         # cancel the notification
         try:
@@ -257,7 +260,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
         """ Reset synchronous state """
 
         # clear the appliances
-        self._appliance_apis.clear()
+        # self._appliance_apis.clear() # MOVED to async_reset to allow for persistence across reconnections
 
         # reset the initialization
         self._all_initial_updates_received.clear()
@@ -459,6 +462,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
             # if we already have the API, switch out its appliance reference for this one
             api = self.appliance_apis[mac_addr]
             api.appliance = appliance
+            api.build_entities_list()
 
     async def _async_maybe_trigger_all_ready(self, force: bool = False) -> None:
         """See if we're all ready to go, and if so, let the games begin."""
@@ -492,7 +496,20 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
         entity_registry = er.async_get(self.hass)
 
         # MAC addresses of all currently valid appliances
-        current_macs = set(self._appliance_apis.keys())
+        # we need to look at the cloud list, not our internal list, as we may have stale entries in our internal list
+        if self._client and self._client.appliances:
+            valid_macs = set(self._client.appliances.keys())
+        else:
+            valid_macs = set()
+
+        # Remove stale appliance APIs from our internal list
+        for mac in list(self._appliance_apis.keys()):
+            if mac not in valid_macs:
+                _LOGGER.info(f"Removing stale appliance API {mac}")
+                self._appliance_apis.pop(mac)
+
+        # Update current macs for HA registry cleanup
+        current_macs = valid_macs
 
         # Loop through all devices for this config entry
         for device_entry in list(device_registry.devices.values()):


### PR DESCRIPTION
This commit addresses an issue where GE Home entities would stop updating and generate 'Platform ge_home does not generate unique IDs' errors.

Example in the forum: https://community.home-assistant.io/t/support-for-ge-appliances-smarthq/283815/103
Reported issue: https://github.com/simbaja/ha_gehome/issues/419

Root Cause:
Previously, the integration cleared its internal device list upon any connection drop. When the client reconnected, new device objects were created, but existing Home Assistant entities remained linked to the old (destroyed) objects. This caused orphans and unique ID conflicts.

Fix:
- Modified _reset_sync_state() to PRESERVE the device list on disconnect, allowing existing entities to reconnect.
- Moved the device list clearing to async_reset() for proper cleanup on unload.
- Updated _async_remove_stale_devices to prune stale devices by cross-referencing against the authoritative cloud roster, preventing 'zombie' devices.

Verification:
- Verified using a standalone reproduction script with mocked components. The simulation confirmed that device objects persist across reconnections and stale devices are correctly removed.
- The fix is tested on a HA setup that had the 'Platform ge_home does not generate unique IDs' issue. The problem is now completely gone.