### PR TITLE
Allow eco mode access for non-heating split ACs

### DIFF
--- a/custom_components/ge_home/entities/ac/ge_sac_climate.py
+++ b/custom_components/ge_home/entities/ac/ge_sac_climate.py
@@ -17,12 +17,9 @@ class SacHvacModeOptionsConverter(OptionsConverter):
 
     @property
     def options(self) -> List[str]:
-        modes = [HVACMode.COOL, HVACMode.FAN_ONLY]
+        modes = [HVACMode.AUTO, HVACMode.COOL, HVACMode.FAN_ONLY]
         if self._available_modes and self._available_modes.has_heat:
             modes.append(HVACMode.HEAT)
-            modes.append(HVACMode.AUTO)
-        elif self._available_modes and self._available_modes.has_energy_saver:
-            modes.append(HVACMode.AUTO)
         if self._available_modes and self._available_modes.has_dry:
             modes.append(HVACMode.DRY)
         return [i.value for i in modes]
@@ -30,17 +27,17 @@ class SacHvacModeOptionsConverter(OptionsConverter):
     def from_option_string(self, value: str) -> Any:
         try:
             hvac = HVACMode(value.lower())
-            mapped = {
+            if self._available_modes and self._available_modes.has_heat:
+                auto_mode = ErdAcOperationMode.AUTO
+            else:
+                auto_mode = ErdAcOperationMode.ENERGY_SAVER
+            return {
+                HVACMode.AUTO: auto_mode,
                 HVACMode.COOL: ErdAcOperationMode.COOL,
                 HVACMode.HEAT: ErdAcOperationMode.HEAT,
                 HVACMode.FAN_ONLY: ErdAcOperationMode.FAN_ONLY,
                 HVACMode.DRY: ErdAcOperationMode.DRY
-            }
-            if self._available_modes and self._available_modes.has_heat:
-                mapped[HVACMode.AUTO] = ErdAcOperationMode.AUTO
-            elif self._available_modes and self._available_modes.has_energy_saver:
-                mapped[HVACMode.AUTO] = ErdAcOperationMode.ENERGY_SAVER
-            return mapped.get(hvac)
+            }.get(hvac)
         except ValueError:
             _LOGGER.warning(f"Could not set HVAC mode to {value.upper()}")
             return ErdAcOperationMode.COOL

--- a/custom_components/ge_home/entities/ac/ge_sac_climate.py
+++ b/custom_components/ge_home/entities/ac/ge_sac_climate.py
@@ -21,20 +21,26 @@ class SacHvacModeOptionsConverter(OptionsConverter):
         if self._available_modes and self._available_modes.has_heat:
             modes.append(HVACMode.HEAT)
             modes.append(HVACMode.AUTO)
+        elif self._available_modes and self._available_modes.has_energy_saver:
+            modes.append(HVACMode.AUTO)
         if self._available_modes and self._available_modes.has_dry:
             modes.append(HVACMode.DRY)
         return [i.value for i in modes]
     
     def from_option_string(self, value: str) -> Any:
         try:
-            hvac = HVACMode(value.lower())    
-            return {
-                HVACMode.AUTO: ErdAcOperationMode.AUTO,
+            hvac = HVACMode(value.lower())
+            mapped = {
                 HVACMode.COOL: ErdAcOperationMode.COOL,
                 HVACMode.HEAT: ErdAcOperationMode.HEAT,
                 HVACMode.FAN_ONLY: ErdAcOperationMode.FAN_ONLY,
                 HVACMode.DRY: ErdAcOperationMode.DRY
-            }.get(hvac)
+            }
+            if self._available_modes and self._available_modes.has_heat:
+                mapped[HVACMode.AUTO] = ErdAcOperationMode.AUTO
+            elif self._available_modes and self._available_modes.has_energy_saver:
+                mapped[HVACMode.AUTO] = ErdAcOperationMode.ENERGY_SAVER
+            return mapped.get(hvac)
         except ValueError:
             _LOGGER.warning(f"Could not set HVAC mode to {value.upper()}")
             return ErdAcOperationMode.COOL


### PR DESCRIPTION
On split AC units, the current implementation reserves the home assistant "auto" mode of the climate entity for the real auto mode implemented on devices with heating support. However, in the absence of heating, these units still have an eco or energy saver mode which could utilize the currently unused home assistant auto setting (just like the window ACs do).

This implementation has the following logic:

Split AC:
Has heating -> HA auto mode links to device auto mode -> exactly the same as before
No heating -> HA auto mode links to device energy saver mode -> additional functionality unlocked for these devices