### PR TITLE
fix: return 0 instead of None from target_temperature when oven is off

### DIFF
--- a/custom_components/ge_home/entities/oven/ge_oven.py
+++ b/custom_components/ge_home/entities/oven/ge_oven.py
@@ -136,7 +136,7 @@ class GeOven(GeAbstractWaterHeater):
         cook_mode = self.current_cook_setting
         if cook_mode.temperature:
             return cook_mode.temperature
-        return None
+        return 0
 
     @property
     def min_temp(self) -> int:


### PR DESCRIPTION
## Problem

When the oven is off, `GeOven.target_temperature` returns `None` because `cook_mode.temperature` is `0` (falsy).

Google Assistant's `report_state.py` → `initial_report` iterates all entities exposed to Google and calls `entity.query_serialize()` → `trait.query_attributes()` → `float(target_temp)`. When `target_temp` is `None`, this raises:

```
TypeError: float() argument must be a string or a real number, not 'NoneType'
```

at `homeassistant/components/google_assistant/trait.py:1112`.

The `initial_report` try/except only catches `SmartHomeError`, not `TypeError`, so this unhandled exception **crashes the entire initial report task** on every HA startup, blocking Google Assistant state reporting for **all** entities — not just the oven.

## Fix

Return `0` instead of `None` when the oven has no active target temperature. This is semantically correct (the oven isn't targeting any temperature) and safe for all consumers since `float(0)` works fine.

## One-line change

```python
# Before
    if cook_mode.temperature:
        return cook_mode.temperature
    return None

# After
    if cook_mode.temperature:
        return cook_mode.temperature
    return 0
```

## Testing

- Verified on HAOS 2026.3.3 with GE Profile oven (dual cavity, upper + lower)
- Both `water_heater.upper_oven` and `water_heater.lower_oven` now report `temperature: 0` when off
- Zero `TypeError` / `report_state` errors in HA logs after restart
- Google Assistant state reporting works correctly for all entities