### PR TITLE
Fix oven off mode casing to match HA STATE_OFF

### DIFF
--- a/custom_components/ge_home/entities/oven/const.py
+++ b/custom_components/ge_home/entities/oven/const.py
@@ -1,12 +1,13 @@
 import bidict
 
 from homeassistant.components.water_heater import WaterHeaterEntityFeature
+from homeassistant.const import STATE_OFF
 from gehomesdk import ErdOvenCookMode
 
 SUPPORT_NONE = WaterHeaterEntityFeature(0)
 GE_OVEN_SUPPORT = (WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.TARGET_TEMPERATURE)
 
-OP_MODE_OFF = "Off"
+OP_MODE_OFF = STATE_OFF
 OP_MODE_BAKE = "Bake"
 OP_MODE_CONVMULTIBAKE = "Conv. Multi-Bake"
 OP_MODE_CONVBAKE = "Convection Bake"


### PR DESCRIPTION
## Summary

- `OP_MODE_OFF` was set to `"Off"` (capitalized) but HA's `STATE_OFF` constant is `"off"` (lowercase)
- This causes the HomeKit Bridge to not recognize the off state — it checks `STATE_OFF in operation_list` which fails because `"off" != "Off"`
- The fix uses `STATE_OFF` directly, matching HA's conventions

## Details

The `WaterHeaterEntity.state` property returns `current_operation` directly. When the oven is off, this returns `"Off"` instead of HA's standard `"off"`. The HomeKit Bridge's `WaterHeater` accessory handler checks `STATE_OFF in operation_list` to determine whether to show an Off toggle — this check fails with the capitalized string.

All internal comparisons in the oven code use the `OP_MODE_OFF` constant, and the appliance only receives the `ErdOvenCookMode` enum (not the string), so this change is safe.

Other water_heater integrations (e.g., Bradford White) already use lowercase `"off"` in their operation lists.

## Test plan

- [x] Verified oven entity state changes from `"Off"` to `"off"` 
- [x] Verified operation_list contains `"off"` (lowercase)
- [x] Verified set_operation_mode("off") correctly turns oven off
- [x] Verified set_operation_mode("Bake") correctly turns oven on
- [x] No impact on non-off operation modes (Bake, Convection, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)