### PR TITLE
Fix HA 2026.1+ compatibility: async_timeout and UnitSystem removal

### DIFF
--- a/custom_components/ge_home/config_flow.py
+++ b/custom_components/ge_home/config_flow.py
@@ -5,7 +5,6 @@ from typing import Dict, Optional
 
 import aiohttp
 import asyncio
-import async_timeout
 
 from gehomesdk import (
     GeAuthFailedError, 
@@ -70,7 +69,7 @@ async def validate_input(hass: core.HomeAssistant, data: dict):
     region = _normalize_region(data.get(CONF_REGION))
 
     try:
-        async with async_timeout.timeout(VALIDATE_DATA_TIMEOUT):
+        async with asyncio.timeout(VALIDATE_DATA_TIMEOUT):
             await async_get_oauth2_token(session, username, password, region)
     except (asyncio.TimeoutError, aiohttp.ClientError) as err:
         _LOGGER.warning(f"Connection failure for user {username} in region {region}: {err}")

--- a/custom_components/ge_home/entities/fridge/convertable_drawer_mode_options.py
+++ b/custom_components/ge_home/entities/fridge/convertable_drawer_mode_options.py
@@ -2,7 +2,7 @@ import logging
 from typing import List, Any, Optional
 
 from homeassistant.const import UnitOfTemperature
-from homeassistant.util.unit_system import UnitSystem
+from homeassistant.util.unit_conversion import TemperatureConverter
 from gehomesdk import ErdConvertableDrawerMode
 
 from ..common import OptionsConverter
@@ -17,7 +17,7 @@ _TEMP_MAP = {
 }
 
 class ConvertableDrawerModeOptionsConverter(OptionsConverter):
-    def __init__(self, units: UnitSystem):
+    def __init__(self, units: Any):
         super().__init__()
         self._excluded_options = [
             ErdConvertableDrawerMode.UNKNOWN0, 
@@ -51,7 +51,7 @@ class ConvertableDrawerModeOptionsConverter(OptionsConverter):
                 t = _TEMP_MAP.get(value, None)
 
                 if t and self._units.temperature_unit == UnitOfTemperature.CELSIUS:
-                    t = self._units.temperature(float(t), UnitOfTemperature.FAHRENHEIT)
+                    t = TemperatureConverter.convert(float(t), UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS)
                     t = round(t,1)
                 
                 if t:


### PR DESCRIPTION
## Summary

- **`config_flow.py`**: Remove `import async_timeout` and replace `async_timeout.timeout()` with `asyncio.timeout()`. The `async_timeout` package was dropped from HA's bundled dependencies in 2024.x; `asyncio.timeout` (Python 3.11+) is the correct replacement.
- **`convertable_drawer_mode_options.py`**: Remove `from homeassistant.util.unit_system import UnitSystem`, which was removed in HA 2026.1. Replace the `UnitSystem.temperature()` conversion call (also removed) with `TemperatureConverter.convert()` from `homeassistant.util.unit_conversion`. Update the type hint from `UnitSystem` to `Any`.

## Context

These two issues caused the integration to fail loading (`not_loaded` state) on HA Core 2026.4 / Python 3.14. The `2026.2.x-working` branch already addressed most 2026.x breakage but missed these two. Verified working on HA Core 2026.4.2.

## Test plan

- [x] Integration loads successfully (`state: loaded`) after HA restart
- [x] Fridge entities with convertable drawer mode render correct temperature labels in both °F and °C unit systems
- [x] Config flow authentication succeeds without errors