### PR TITLE
Restore appliance availability on state update

### DIFF
--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -381,6 +381,8 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(f"on_device_update: skipping invalid appliance {appliance.mac_addr}")
             return
 
+        self._ensure_appliance_available(appliance)
+
         try:
             api = self.appliance_apis[appliance.mac_addr]
         except KeyError:
@@ -420,6 +422,7 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug(f"Got initial update for {appliance.mac_addr}")
 
         self.last_update_success = True
+        self._ensure_appliance_available(appliance)
         self._maybe_add_appliance_api(appliance)
         await self._async_maybe_trigger_all_ready()
         await self._start_periodic_updates()
@@ -441,6 +444,17 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
 
     def _is_appliance_valid(self, appliance: GeAppliance) -> bool:
         return appliance.appliance_type is not None
+
+    def _ensure_appliance_available(self, appliance: GeAppliance) -> None:
+        """Treat successful SmartHQ state traffic as proof the appliance is online."""
+        if appliance.available:
+            return
+
+        _LOGGER.info(
+            "Marking appliance %s available after receiving a successful state update",
+            appliance.mac_addr,
+        )
+        appliance.set_available()
 
     def _get_appliance_api(self, appliance: GeAppliance) -> ApplianceApi:
         if appliance is None:


### PR DESCRIPTION
## Summary

Marks an appliance available when the coordinator receives a valid SmartHQ state update for it.

## Why

Entities derive availability from the SDK appliance availability flag. If that flag remains false after a prior disconnect or auth failure, the integration can continue to receive fresh ERD state data while Home Assistant still renders the entities as unavailable.

Successful state traffic from SmartHQ indicates the appliance is reachable, so the coordinator should restore the availability flag before refreshing entity state.

## Validation

- Ran Python syntax compilation for `custom_components/ge_home/update_coordinator.py`.
- Verified the change locally against a GE oven that was receiving state updates while its Home Assistant entities remained unavailable; after restart, oven entities reported normal states again.
