### PR TITLE
Ignore non-printable serial numbers and fall back to MAC as unique device identifer

### DIFF
--- a/custom_components/ge_home/devices/base.py
+++ b/custom_components/ge_home/devices/base.py
@@ -82,10 +82,17 @@ class ApplianceApi:
             except:
                 return False
     
-        if (self.serial_number and not 
-            self.serial_number.isspace() and not 
-            is_zero(self.serial_number)):
+        if (self.serial_number and not
+            self.serial_number.isspace() and not
+            is_zero(self.serial_number) and
+            self.serial_number.isprintable()):
             return self.serial_number
+        if self.serial_number and not self.serial_number.isprintable():
+            _LOGGER.warning(
+                "Serial number for %s contains non-printable characters "
+                "(possible certificate data on ERD 0x0002); falling back to MAC address.",
+                self.mac_addr,
+            )
         return self.mac_addr
 
     @cached_property


### PR DESCRIPTION
This is the HA version of the same workaround as https://github.com/simbaja/gehome/pull/112 to ignore non-printable serial numbers returned by the server. The HA integration will cleanly fall back to the MAC address in this case.

It's another way to fix #490 ; we can land either or both of them.
