### PR TITLE
Fix AttributeError on AC registration after gehomesdk 2026.5 rename

### DIFF
--- a/custom_components/ge_home/devices/biac.py
+++ b/custom_components/ge_home/devices/biac.py
@@ -11,6 +11,15 @@ from ..entities import GeSacClimate, GeErdSensor, GeErdSwitch, ErdOnOffBoolConve
 
 _LOGGER = logging.getLogger(__name__)
 
+# gehomesdk 2026.5 renamed/removed these codes (STATE was renamed,
+# POWER's address is now a struct with no scalar replacement). Resolve
+# via getattr so this module imports on both pre- and post-2026.5 SDKs.
+_DEMAND_RESPONSE_STATE = (
+    getattr(ErdCode, "RESOURCE_DEMAND_RESPONSE_STATE", None)
+    or getattr(ErdCode, "WAC_DEMAND_RESPONSE_STATE", None)
+)
+_DEMAND_RESPONSE_POWER = getattr(ErdCode, "WAC_DEMAND_RESPONSE_POWER", None)
+
 
 class BiacApi(ApplianceApi):
     """API class for Built-In AC objects"""
@@ -27,9 +36,15 @@ class BiacApi(ApplianceApi):
             GeErdSensor(self, ErdCode.AC_OPERATION_MODE, entity_category=EntityCategory.DIAGNOSTIC),
             GeErdSwitch(self, ErdCode.AC_POWER_STATUS, bool_converter=ErdOnOffBoolConverter(), icon_on_override="mdi:power-on", icon_off_override="mdi:power-off"),
             GeErdBinarySensor(self, ErdCode.AC_FILTER_STATUS, device_class_override="problem", entity_category=EntityCategory.DIAGNOSTIC),
-            GeErdSensor(self, ErdCode.WAC_DEMAND_RESPONSE_STATE, entity_category=EntityCategory.DIAGNOSTIC),
-            GeErdSensor(self, ErdCode.WAC_DEMAND_RESPONSE_POWER, uom_override="kW", entity_category=EntityCategory.DIAGNOSTIC),
         ]
+        if _DEMAND_RESPONSE_STATE is not None:
+            sac_entities.append(
+                GeErdSensor(self, _DEMAND_RESPONSE_STATE, entity_category=EntityCategory.DIAGNOSTIC)
+            )
+        if _DEMAND_RESPONSE_POWER is not None:
+            sac_entities.append(
+                GeErdSensor(self, _DEMAND_RESPONSE_POWER, uom_override="kW", entity_category=EntityCategory.DIAGNOSTIC)
+            )
 
         entities = base_entities + sac_entities
         return entities

--- a/custom_components/ge_home/devices/wac.py
+++ b/custom_components/ge_home/devices/wac.py
@@ -10,6 +10,15 @@ from ..entities import GeWacClimate, GeErdSensor, GeErdBinarySensor, GeErdSwitch
 
 _LOGGER = logging.getLogger(__name__)
 
+# gehomesdk 2026.5 renamed/removed these codes (STATE was renamed,
+# POWER's address is now a struct with no scalar replacement). Resolve
+# via getattr so this module imports on both pre- and post-2026.5 SDKs.
+_DEMAND_RESPONSE_STATE = (
+    getattr(ErdCode, "RESOURCE_DEMAND_RESPONSE_STATE", None)
+    or getattr(ErdCode, "WAC_DEMAND_RESPONSE_STATE", None)
+)
+_DEMAND_RESPONSE_POWER = getattr(ErdCode, "WAC_DEMAND_RESPONSE_POWER", None)
+
 
 class WacApi(ApplianceApi):
     """API class for Window AC objects"""
@@ -26,9 +35,15 @@ class WacApi(ApplianceApi):
             GeErdSensor(self, ErdCode.AC_OPERATION_MODE, entity_category=EntityCategory.DIAGNOSTIC),
             GeErdSwitch(self, ErdCode.AC_POWER_STATUS, bool_converter=ErdOnOffBoolConverter(), icon_on_override="mdi:power-on", icon_off_override="mdi:power-off"),
             GeErdBinarySensor(self, ErdCode.AC_FILTER_STATUS, device_class_override="problem", entity_category=EntityCategory.DIAGNOSTIC),
-            GeErdSensor(self, ErdCode.WAC_DEMAND_RESPONSE_STATE, entity_category=EntityCategory.DIAGNOSTIC),
-            GeErdSensor(self, ErdCode.WAC_DEMAND_RESPONSE_POWER, uom_override="kW", entity_category=EntityCategory.DIAGNOSTIC),
         ]
+        if _DEMAND_RESPONSE_STATE is not None:
+            wac_entities.append(
+                GeErdSensor(self, _DEMAND_RESPONSE_STATE, entity_category=EntityCategory.DIAGNOSTIC)
+            )
+        if _DEMAND_RESPONSE_POWER is not None:
+            wac_entities.append(
+                GeErdSensor(self, _DEMAND_RESPONSE_POWER, uom_override="kW", entity_category=EntityCategory.DIAGNOSTIC)
+            )
         entities = base_entities + wac_entities
         return entities
         


### PR DESCRIPTION
## Bug

After updating to `gehomesdk` 2026.5 my Built-In AC units (AJCQ12AWHK1 and AJCQ08AWHK1) stopped registering in HA correctly.

Sensors and control greyed out and became unavailable:
<img width="1303" height="924" alt="bricked_ac_units" src="https://github.com/user-attachments/assets/9dc24e5a-ea1a-40ac-8acd-60c641ca4dce" />

 From `update_coordinator` in HA ha_gehome logs:

```
File "/config/custom_components/ge_home/devices/biac.py", line 30, in get_all_entities
    GeErdSensor(self, ErdCode.WAC_DEMAND_RESPONSE_STATE, entity_category=EntityCategory.DIAGNOSTIC),
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'ErdCode' has no attribute 'WAC_DEMAND_RESPONSE_STATE'. Did you mean: 'RESOURCE_DEMAND_RESPONSE_STATE'?
```

Followed about 10 seconds later by:

```
custom_components.ge_home.update_coordinator: Timeout waiting for initial appliance updates
```

Tried clean installing, re-authing, etc, with similar errors

## Cause

gehomesdk simbaja/gehome@3185b34 (2026-05-26, "added resource ERD codes (e.g. power/water usage)") renamed the demand-response codes:

- `WAC_DEMAND_RESPONSE_STATE` (`0xd006`) became `RESOURCE_DEMAND_RESPONSE_STATE` (same address, same enum payload).
- `WAC_DEMAND_RESPONSE_POWER` (`0xd005`) became `RESOURCE_DSM_POWER_USAGE` (same address, but the value is now a 22-byte multi-field struct with `instantaneous_power_w`, `watt_seconds_since_clear`, etc, not a scalar).

The rename itself is good, those codes are cross-appliance DSM / metering, not WAC-specific, but no deprecation aliases were left behind on `ErdCode`, so anything referencing the old names by attribute fails on import.

## Fix

Shimmed the rename in `biac.py` and `wac.py`: look up whichever name the installed SDK has:

```python
_DEMAND_RESPONSE_STATE = (
    getattr(ErdCode, "RESOURCE_DEMAND_RESPONSE_STATE", None)
    or getattr(ErdCode, "WAC_DEMAND_RESPONSE_STATE", None)
)
_DEMAND_RESPONSE_POWER = getattr(ErdCode, "WAC_DEMAND_RESPONSE_POWER", None)
```

Works on any SDK from 2026.2 onward, `manifest.json` untouched. Nobody whose integration was working yesterday gets force-upgraded.

The power sensor gets the same shim treatment. There's no scalar replacement at `0xd005` on the new SDK (it's now a struct), so old-SDK users keep the sensor exactly as before, and new-SDK users won't have it until someone writes a small wrapper around `ErdDsmPowerUsage.instantaneous_power_w`. Happy to send that follow-up if anyone wants it.

## Verified

With the patch:

- `AttributeError` gone from logs
- "Timeout waiting for initial appliance updates" gone
- Able to read and control the GE Units, no more `unavailable` messaging
<img width="1038" height="794" alt="image" src="https://github.com/user-attachments/assets/e2894cb5-34d5-43f3-8efb-1973cfb1da77" />



## SDK follow-up

A one-line alias on `ErdCode` in `simbaja/gehome` (e.g. `WAC_DEMAND_RESPONSE_STATE = RESOURCE_DEMAND_RESPONSE_STATE`) would have made this transparent to every downstream consumer. Worth a separate PR there for any community integrations that quietly broke at the same time.