### PR TITLE
Update hood controls for better UX in HomeAssistant and Apple Home UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Feature: Added DRY mode to HVAC options and mappings [#441]
 - Feature: Added GeWasherCycleButton to WasherDryerApi [#462]
 - Feature: Added DishDrawer User Setting wifi_enabled (read only) [#463]
+- Feature: Added native fan and light entities for range hoods
 - Change: Changed mode names for Haier water heaters [#442]
 - Change: Made LAUNDRY_MACHINE_STATE diagnostic on all appliances [#447]
 - Bugfix: Cooktop Sensor fixes [#440, #454]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ A/C Controls:
 
 ![A/C controls](https://raw.githubusercontent.com/simbaja/ha_components/master/img/ac_controls.png)
 
+## Range Hood HomeKit Controls
+
+Range hoods expose native `fan` and `light` entities when the appliance reports hood fan speed and light level controls. These entities are intended to work better with Home Assistant dashboards, voice assistants, and the HomeKit Bridge than the lower-level select entities. Hood fans expose low, medium, and high as regular fan speeds; boost is exposed as a preset mode when available.
+
+The existing hood fan speed and light level select entities remain available for compatibility, but are disabled by default for new entity registry entries. Re-enable them from the entity settings if you use them in dashboards, scripts, or automations. For the best HomeKit experience, expose the `fan` and `light` hood entities to the HomeKit Bridge and exclude any helper switches or select entities that were previously used to represent individual hood modes.
+
 ## Installation (Manual)
 
 1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).

--- a/custom_components/ge_home/devices/base.py
+++ b/custom_components/ge_home/devices/base.py
@@ -185,8 +185,13 @@ class ApplianceApi:
         m = model.strip().upper()
 
         # Try special prefixes
-        for prefix, idx in BRAND_SPECIAL_PREFIXES.items():
+        for prefix, brand_or_idx in BRAND_SPECIAL_PREFIXES.items():
             if m.startswith(prefix):
+                if isinstance(brand_or_idx, ErdBrand):
+                    _LOGGER.debug(f"Model '{m}': inferred brand '{brand_or_idx.name}' from prefix '{prefix}'")
+                    return brand_or_idx
+
+                idx = brand_or_idx
                 if len(m) > idx:
                     brand_letter = m[idx]
                     brand = BRAND_FIRST_LETTER_MAP.get(brand_letter)

--- a/custom_components/ge_home/devices/const.py
+++ b/custom_components/ge_home/devices/const.py
@@ -16,7 +16,8 @@ BRAND_FIRST_LETTER_MAP: dict[str, ErdBrand] = {
     "U": ErdBrand.UNKNOWN,  # also might be universal
 }
 
-BRAND_SPECIAL_PREFIXES: dict[str, int] = {
+BRAND_SPECIAL_PREFIXES: dict[str, int | ErdBrand] = {
+    "UVC": ErdBrand.GE,  # GE vent hoods
     "OPAL01": 6,  # Opal ice maker: brand letter at 7th position
     "XP": 1,      # XP Opal variant: brand letter at 2nd position
 }

--- a/custom_components/ge_home/devices/hood.py
+++ b/custom_components/ge_home/devices/hood.py
@@ -14,6 +14,8 @@ from gehomesdk import (
 
 from .base import ApplianceApi
 from ..entities import (
+    GeHoodFan,
+    GeHoodLight,
     GeHoodLightLevelSelect, 
     GeHoodFanSpeedSelect, 
     GeErdTimerSensor, 
@@ -49,15 +51,27 @@ class HoodApi(ApplianceApi):
 
         #old-style
         if fan_availability is not None and fan_availability.is_available:
-            hood_entities.append(GeHoodFanSpeedSelect(self, ErdCode.HOOD_FAN_SPEED))
+            hood_entities.append(GeHoodFanSpeedSelect(self, ErdCode.HOOD_FAN_SPEED, enabled_default=False))
         if light_availability is not None and light_availability.is_available:
-            hood_entities.append(GeHoodLightLevelSelect(self, ErdCode.HOOD_LIGHT_LEVEL))
+            hood_entities.append(GeHoodLightLevelSelect(self, ErdCode.HOOD_LIGHT_LEVEL, enabled_default=False))
         
         #new-style
         if available_fan_speeds is not None and available_fan_speeds > 0 and actual_fan_speed is not None:
-            hood_entities.append(GeHoodFanSpeedSelect(self, ErdCode.HOOD_ACTUAL_FAN_SPEED, ErdCode.HOOD_REQUESTED_FAN_SPEED))
+            hood_entities.append(GeHoodFanSpeedSelect(self, ErdCode.HOOD_ACTUAL_FAN_SPEED, ErdCode.HOOD_REQUESTED_FAN_SPEED, enabled_default=False))
         if available_light_levels is not None and available_light_levels > 0 and actual_light_level is not None:
-            hood_entities.append(GeHoodLightLevelSelect(self, ErdCode.HOOD_ACTUAL_LIGHT_LEVEL, ErdCode.HOOD_REQUESTED_LIGHT_LEVEL))
+            hood_entities.append(GeHoodLightLevelSelect(self, ErdCode.HOOD_ACTUAL_LIGHT_LEVEL, ErdCode.HOOD_REQUESTED_LIGHT_LEVEL, enabled_default=False))
+
+        #native fan entity for Home Assistant / HomeKit
+        if available_fan_speeds is not None and available_fan_speeds > 0 and actual_fan_speed is not None:
+            hood_entities.append(GeHoodFan(self, ErdCode.HOOD_ACTUAL_FAN_SPEED, ErdCode.HOOD_REQUESTED_FAN_SPEED))
+        elif fan_availability is not None and fan_availability.is_available:
+            hood_entities.append(GeHoodFan(self, ErdCode.HOOD_FAN_SPEED))
+
+        #native light entity for Home Assistant / HomeKit
+        if available_light_levels is not None and available_light_levels > 0 and actual_light_level is not None:
+            hood_entities.append(GeHoodLight(self, ErdCode.HOOD_ACTUAL_LIGHT_LEVEL, ErdCode.HOOD_REQUESTED_LIGHT_LEVEL))
+        elif light_availability is not None and light_availability.is_available:
+            hood_entities.append(GeHoodLight(self, ErdCode.HOOD_LIGHT_LEVEL))
 
         #timer
         if timer_availability is not None:

--- a/custom_components/ge_home/entities/hood/__init__.py
+++ b/custom_components/ge_home/entities/hood/__init__.py
@@ -1,2 +1,2 @@
-from .ge_hood_fan_speed import GeHoodFanSpeedSelect
-from .ge_hood_light_level import GeHoodLightLevelSelect
+from .ge_hood_fan_speed import GeHoodFan, GeHoodFanSpeedSelect
+from .ge_hood_light_level import GeHoodLight, GeHoodLightLevelSelect

--- a/custom_components/ge_home/entities/hood/ge_hood_fan_speed.py
+++ b/custom_components/ge_home/entities/hood/ge_hood_fan_speed.py
@@ -1,9 +1,12 @@
 import logging
 from typing import List, Any, Optional
 
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from propcache.api import cached_property
 from gehomesdk import ErdCodeType, ErdHoodFanSpeedAvailability, ErdHoodFanSpeed, ErdCode
+from ...const import DOMAIN
 from ...devices import ApplianceApi
-from ..common import GeErdSelect, OptionsConverter
+from ..common import GeErdEntity, GeErdSelect, OptionsConverter
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +44,33 @@ class HoodFanSpeedOptionsConverter(OptionsConverter):
         return ErdHoodFanSpeed.OFF.stringify()
 
 class GeHoodFanSpeedSelect(GeErdSelect):
+    def __init__(
+            self,
+            api: ApplianceApi,
+            erd_code: ErdCodeType,
+            control_erd_code: Optional[ErdCodeType] = None,
+            enabled_default: bool = True
+        ):
+
+        # old-style
+        self._availability: ErdHoodFanSpeedAvailability | None = api.try_get_erd_value(ErdCode.HOOD_FAN_SPEED_AVAILABILITY)
+
+        # new-style
+        if self._availability is None:
+            fs: int | None = api.try_get_erd_value(ErdCode.HOOD_AVAILABLE_FAN_SPEEDS)
+            if fs is not None:
+                self._availability = ErdHoodFanSpeedAvailability.from_count(fs)
+
+        # default
+        if self._availability is None:
+            self._availability = ErdHoodFanSpeedAvailability(off_available=True)
+
+        self._attr_entity_registry_enabled_default = enabled_default
+        super().__init__(api, erd_code, HoodFanSpeedOptionsConverter(self._availability), control_erd_code=control_erd_code)
+
+class GeHoodFan(GeErdEntity, FanEntity):
+    """Fan entity for GE hood fan speed controls."""
+
     def __init__(self, api: ApplianceApi, erd_code: ErdCodeType, control_erd_code: Optional[ErdCodeType] = None):
 
         # old-style
@@ -56,4 +86,136 @@ class GeHoodFanSpeedSelect(GeErdSelect):
         if self._availability is None:
             self._availability = ErdHoodFanSpeedAvailability(off_available=True)
 
-        super().__init__(api, erd_code, HoodFanSpeedOptionsConverter(self._availability), control_erd_code=control_erd_code)
+        super().__init__(api, erd_code)
+        self._converter = HoodFanSpeedOptionsConverter(self._availability)
+        self._control_erd_code = control_erd_code
+        self._requested_percentage: int | None = None
+
+    @cached_property
+    def name(self) -> Optional[str]:
+        return f"{self.serial_or_mac} Hood Fan"
+
+    @cached_property
+    def unique_id(self) -> Optional[str]:
+        return f"{DOMAIN}_{self.serial_or_mac}_hood_fan"
+
+    @property
+    def icon(self) -> str | None:
+        return "mdi:fan"
+
+    @property
+    def available(self) -> bool: # type: ignore
+        return super().available
+
+    @cached_property
+    def supported_features(self) -> FanEntityFeature:
+        features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        if self._boost_option is not None:
+            features |= FanEntityFeature.PRESET_MODE
+        return features
+
+    @cached_property
+    def speed_count(self) -> int:
+        return len(self._speed_options)
+
+    @property
+    def is_on(self) -> bool | None: # type: ignore
+        return self.current_option.lower() != ErdHoodFanSpeed.OFF.stringify().lower()
+
+    @property
+    def percentage(self) -> int | None: # type: ignore
+        option = self.current_option
+        if option.lower() == ErdHoodFanSpeed.OFF.stringify().lower():
+            return 0
+        if self._boost_option is not None and option.lower() == self._boost_option.lower():
+            return 100
+
+        try:
+            speed_index = self._speed_options.index(option) + 1
+            return (speed_index * 100) // self.speed_count
+        except ValueError:
+            _LOGGER.debug(f"Unable to map hood fan speed {option} to percentage")
+            return 0
+
+    @property
+    def preset_mode(self) -> str | None: # type: ignore
+        if self._boost_option is not None and self.current_option.lower() == self._boost_option.lower():
+            return self._boost_option
+        return None
+
+    @cached_property
+    def preset_modes(self) -> list[str] | None:
+        if self._boost_option is not None:
+            return [self._boost_option]
+        return None
+
+    @property
+    def current_option(self) -> str:
+        return self._converter.to_option_string(self.appliance.get_erd_value(self.erd_code))
+
+    @cached_property
+    def _speed_options(self) -> List[str]:
+        return [
+            option
+            for option in self._converter.options
+            if option.lower() not in (
+                ErdHoodFanSpeed.OFF.stringify().lower(),
+                ErdHoodFanSpeed.BOOST.stringify().lower(),
+            )
+        ]
+
+    @cached_property
+    def _boost_option(self) -> str | None:
+        return next(
+            (
+                option
+                for option in self._converter.options
+                if option.lower() == ErdHoodFanSpeed.BOOST.stringify().lower()
+            ),
+            None
+        )
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the hood fan speed percentage."""
+        self._requested_percentage = percentage
+        option = self._option_from_percentage(percentage)
+        if option != self.current_option:
+            _LOGGER.debug(f"Setting hood fan from {self.current_option} to {option}")
+            await self.appliance.async_set_erd_value(self._writeable_erd_code, self._converter.from_option_string(option))
+
+    async def async_turn_on(self, percentage: int | None = None, preset_mode: str | None = None, **kwargs):
+        """Turn the hood fan on."""
+        if percentage is None:
+            # HomeKit may set speed before active state; preserve that request.
+            # Plain "on" commands still default to a middle speed instead of boost.
+            percentage = self._requested_percentage or self.percentage or 50
+        await self.async_set_percentage(percentage)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the hood fan off."""
+        await self.async_set_percentage(0)
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the hood fan preset mode."""
+        if self._boost_option is None or preset_mode.lower() != self._boost_option.lower():
+            raise ValueError(f"Unsupported hood fan preset mode: {preset_mode}")
+
+        self._requested_percentage = 100
+        if self.current_option.lower() != self._boost_option.lower():
+            _LOGGER.debug(f"Setting hood fan from {self.current_option} to {self._boost_option}")
+            await self.appliance.async_set_erd_value(self._writeable_erd_code, self._converter.from_option_string(self._boost_option))
+
+    def _option_from_percentage(self, percentage: int) -> str:
+        if percentage <= 0 or self.speed_count == 0:
+            return ErdHoodFanSpeed.OFF.stringify()
+
+        speed_index = round((percentage * self.speed_count) / 100)
+        speed_index = min(max(speed_index, 1), self.speed_count)
+        return self._speed_options[speed_index - 1]
+
+    @property
+    def _writeable_erd_code(self) -> ErdCodeType:
+        if self._control_erd_code:
+            return self._control_erd_code
+
+        return self.erd_code

--- a/custom_components/ge_home/entities/hood/ge_hood_light_level.py
+++ b/custom_components/ge_home/entities/hood/ge_hood_light_level.py
@@ -1,9 +1,13 @@
 import logging
 from typing import List, Any, Optional
 
+from homeassistant.components.light import ATTR_BRIGHTNESS, LightEntity
+from homeassistant.components.light.const import ColorMode
+from propcache.api import cached_property
 from gehomesdk import ErdCodeType, ErdHoodLightLevelAvailability, ErdHoodLightLevel, ErdHoodLightLevelNew, ErdCode
+from ...const import DOMAIN
 from ...devices import ApplianceApi
-from ..common import GeErdSelect, OptionsConverter
+from ..common import GeErdEntity, GeErdSelect, OptionsConverter
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,19 +73,131 @@ class HoodLightLevelNewOptionsConverter(OptionsConverter):
             pass
         return ErdHoodLightLevelNew.OFF.stringify()
 
+def detect_hood_light_level(api: ApplianceApi):
+    if (a := api.try_get_erd_value(ErdCode.HOOD_LIGHT_LEVEL_AVAILABILITY)) is not None:
+        return a, HoodLightLevelOptionsConverter(a)
+
+    if (ll := api.try_get_erd_value(ErdCode.HOOD_AVAILABLE_LIGHT_LEVELS)) is not None:
+        a = ErdHoodLightLevelAvailability.from_count(ll)
+        return a, HoodLightLevelNewOptionsConverter(a)
+
+    a = ErdHoodLightLevelAvailability(off_available=True)
+    return a, HoodLightLevelOptionsConverter(a)
+
 
 class GeHoodLightLevelSelect(GeErdSelect):
-    def __init__(self, api: ApplianceApi, erd_code: ErdCodeType, control_erd_code: Optional[ErdCodeType] = None):
-        self._availability, converter = self._detect_availability(api)
+    def __init__(
+            self,
+            api: ApplianceApi,
+            erd_code: ErdCodeType,
+            control_erd_code: Optional[ErdCodeType] = None,
+            enabled_default: bool = True
+        ):
+        self._availability, converter = detect_hood_light_level(api)
+        self._attr_entity_registry_enabled_default = enabled_default
         super().__init__(api, erd_code, converter, control_erd_code=control_erd_code)
 
-    def _detect_availability(self, api: ApplianceApi):
-        if (a := api.try_get_erd_value(ErdCode.HOOD_LIGHT_LEVEL_AVAILABILITY)) is not None:
-            return a, HoodLightLevelOptionsConverter(a)
+class GeHoodLight(GeErdEntity, LightEntity):
+    """Light entity for GE hood light level controls."""
 
-        if (ll := api.try_get_erd_value(ErdCode.HOOD_AVAILABLE_LIGHT_LEVELS)) is not None:
-            a = ErdHoodLightLevelAvailability.from_count(ll)
-            return a, HoodLightLevelNewOptionsConverter(a)
+    def __init__(self, api: ApplianceApi, erd_code: ErdCodeType, control_erd_code: Optional[ErdCodeType] = None):
+        self._availability, self._converter = detect_hood_light_level(api)
+        self._control_erd_code = control_erd_code
+        super().__init__(api, erd_code)
 
-        a = ErdHoodLightLevelAvailability(off_available=True)
-        return a, HoodLightLevelOptionsConverter(a)
+    @cached_property
+    def name(self) -> Optional[str]:
+        return f"{self.serial_or_mac} Hood Light"
+
+    @cached_property
+    def unique_id(self) -> Optional[str]:
+        return f"{DOMAIN}_{self.serial_or_mac}_hood_light"
+
+    @property
+    def icon(self) -> str | None:
+        return "mdi:lightbulb"
+
+    @property
+    def available(self) -> bool: # type: ignore
+        return super().available
+
+    @cached_property
+    def supported_color_modes(self) -> set[ColorMode]:
+        """Flag supported color modes."""
+        return set([ColorMode.BRIGHTNESS])
+
+    @property
+    def color_mode(self) -> ColorMode: # type: ignore
+        """Return the color mode of the light."""
+        return ColorMode.BRIGHTNESS
+
+    @property
+    def brightness(self) -> int | None: # type: ignore
+        """Return the brightness of the light."""
+        option = self.current_option
+        if option == self._off_option:
+            return 0
+
+        try:
+            level_index = self._light_options.index(option) + 1
+            return round((level_index * 255) / len(self._light_options))
+        except ValueError:
+            _LOGGER.debug(f"Unable to map hood light level {option} to brightness")
+            return 0
+
+    @property
+    def is_on(self) -> bool: # type: ignore
+        """Return True if light is on."""
+        return self.current_option != self._off_option
+
+    @property
+    def current_option(self) -> str:
+        return self._converter.to_option_string(self.appliance.get_erd_value(self.erd_code))
+
+    @cached_property
+    def _off_option(self) -> str:
+        return next(
+            (
+                option
+                for option in self._converter.options
+                if option.lower() == ErdHoodLightLevel.OFF.stringify().lower()
+            ),
+            ErdHoodLightLevel.OFF.stringify()
+        )
+
+    @cached_property
+    def _light_options(self) -> List[str]:
+        return [
+            option
+            for option in self._converter.options
+            if option.lower() != self._off_option.lower()
+        ]
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the light on."""
+        brightness = kwargs.pop(ATTR_BRIGHTNESS, self.brightness or 255)
+        option = self._option_from_brightness(brightness)
+        if option != self.current_option:
+            _LOGGER.debug(f"Setting hood light from {self.current_option} to {option}")
+            await self.appliance.async_set_erd_value(self._writeable_erd_code, self._converter.from_option_string(option))
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the light off."""
+        if self.current_option != self._off_option:
+            _LOGGER.debug(f"Turning off {self.unique_id}")
+            await self.appliance.async_set_erd_value(self._writeable_erd_code, self._converter.from_option_string(self._off_option))
+
+    def _option_from_brightness(self, brightness: int) -> str:
+        if brightness <= 0 or len(self._light_options) == 0:
+            return self._off_option
+
+        level_index = round((brightness * len(self._light_options)) / 255)
+        level_index = min(max(level_index, 1), len(self._light_options))
+        return self._light_options[level_index - 1]
+
+    @property
+    def _writeable_erd_code(self) -> ErdCodeType:
+        if self._control_erd_code:
+            return self._control_erd_code
+
+        return self.erd_code

--- a/custom_components/ge_home/fan.py
+++ b/custom_components/ge_home/fan.py
@@ -1,4 +1,4 @@
-"""GE Home Select Entities"""
+"""GE Home Fan Entities"""
 import logging
 from collections.abc import Collection
 from typing import Callable
@@ -8,34 +8,32 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers import entity_registry as er
 
+from .entities import GeHoodFan
 from .const import DOMAIN
-from .entities import GeErdLight, GeHoodLight
 from .devices import ApplianceApi
 from .update_coordinator import GeHomeUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable
-):
-    """GE Home lights."""
-    _LOGGER.debug("Adding GE Home lights")
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable):
+    """GE Home fans"""
+    _LOGGER.debug('Adding GE "Fans"')
     coordinator: GeHomeUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    registry = er.async_get(hass)    
+    registry = er.async_get(hass)
 
     @callback
     def async_devices_discovered(apis: Collection[ApplianceApi]):
-        _LOGGER.debug(f"Found {len(apis):d} appliance APIs")
+        _LOGGER.debug(f'Found {len(apis):d} appliance APIs')
         entities = [
             entity
             for api in apis
             for entity in api.entities
-            if isinstance(entity, (GeErdLight, GeHoodLight))
+            if isinstance(entity, GeHoodFan)
             and entity.erd_code in api.appliance._property_cache
             if not registry.async_is_registered(entity.entity_id)
         ]
-        _LOGGER.debug(f"Found {len(entities):d} unregistered lights to register")
+        _LOGGER.debug(f'Found {len(entities):d} unregistered fans to register')
         async_add_entities(entities)
 
     #if we're already initialized at this point, call device
@@ -43,7 +41,7 @@ async def async_setup_entry(
     #ready signal
     if coordinator.initialized:
         async_devices_discovered(coordinator.appliance_apis.values())
-    else:    
+    else:
         # add the ready signal and register the remove callback
         coordinator.add_signal_remove_callback(
             async_dispatcher_connect(hass, coordinator.signal_ready, async_devices_discovered))

--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -43,6 +43,7 @@ PLATFORMS = [
     "water_heater", 
     "select", 
     "climate", 
+    "fan",
     "light", 
     "button", 
     "number",


### PR DESCRIPTION
Disclaimer: I'm not a Python dev and I am very new to the HA scene. This PR is 100% made via Codex, and I've been testing this over the past 3 days. I'm opening this PR as a draft for feedback. If there's anything ridiculous here, I apologize in advance for the robots.

This PR attempts to improve the UI for controlling the fan and light entities exposed by GE vent hoods. When I initially added this to my HA instance, I found the functionality to work well but was unhappy with how the discrete fan speeds and light brightness options were exposed to Homekit via "select" entities.

Using the precedent set by how other fan integrations with discrete steps work, I asked Codex to come up with an approach to re-implement the vent hood fan as a proper "fan" entity, and did the same with the light to expose it as a brightness slider.

<img width="634" height="676" alt="Screenshot 2026-06-01 at 7 10 26 AM" src="https://github.com/user-attachments/assets/d44b444b-b107-44cb-8788-47ad6df8f0c9" />
<img width="616" height="641" alt="Screenshot 2026-06-01 at 7 10 10 AM" src="https://github.com/user-attachments/assets/db3c4a32-33eb-48c0-bfbc-98c04d6f5b3b" />
<img width="781" height="239" alt="Screenshot 2026-06-01 at 7 09 54 AM" src="https://github.com/user-attachments/assets/5e0d370f-931b-4802-a89e-21b4899b5a8e" />
<img width="317" height="622" alt="Screenshot 2026-06-01 at 7 09 28 AM" src="https://github.com/user-attachments/assets/aa215170-b3c0-4730-a7a4-8428b8b2b92e" />
<img width="302" height="617" alt="Screenshot 2026-06-01 at 7 09 16 AM" src="https://github.com/user-attachments/assets/5f4b0bae-32cc-4190-96e9-8b90809e4997" />

The PR attempts to be backwards compatible with existing installs that use the "select" entities. It will expose new, duplicate "fan" and "light" entities in addition to the "legacy" ones. We updated the readme to reflect this.

And one more small fix while I was at it, it looks like there was an issue with how my device was reporting the manufacturer and model number, and I asked Codex to attempt a fix. The issue being that my hood model is `UVC..` which maps the first character `U` to `unknown`.

Thanks for working on this integration! 