### PR TITLE
Port upstream #519 + #520: bump gehomesdk and fix AC demand-response …

### DIFF
--- a/custom_components/ge_home/devices/biac.py
+++ b/custom_components/ge_home/devices/biac.py
@@ -19,6 +19,17 @@ class BiacApi(ApplianceApi):
     def get_all_entities(self) -> List[Entity]:
         base_entities = super().get_all_entities()
 
+        demand_response_state_erd = getattr(
+            ErdCode,
+            "WAC_DEMAND_RESPONSE_STATE",
+            getattr(ErdCode, "RESOURCE_DEMAND_RESPONSE_STATE", None),
+        )
+        demand_response_power_erd = getattr(
+            ErdCode,
+            "WAC_DEMAND_RESPONSE_POWER",
+            getattr(ErdCode, "RESOURCE_DEMAND_RESPONSE_POWER", None),
+        )
+
         sac_entities = [
             GeSacClimate(self),
             GeErdSensor(self, ErdCode.AC_TARGET_TEMPERATURE, entity_category=EntityCategory.DIAGNOSTIC),
@@ -27,9 +38,16 @@ class BiacApi(ApplianceApi):
             GeErdSensor(self, ErdCode.AC_OPERATION_MODE, entity_category=EntityCategory.DIAGNOSTIC),
             GeErdSwitch(self, ErdCode.AC_POWER_STATUS, bool_converter=ErdOnOffBoolConverter(), icon_on_override="mdi:power-on", icon_off_override="mdi:power-off"),
             GeErdBinarySensor(self, ErdCode.AC_FILTER_STATUS, device_class_override="problem", entity_category=EntityCategory.DIAGNOSTIC),
-            GeErdSensor(self, ErdCode.WAC_DEMAND_RESPONSE_STATE, entity_category=EntityCategory.DIAGNOSTIC),
-            GeErdSensor(self, ErdCode.WAC_DEMAND_RESPONSE_POWER, uom_override="kW", entity_category=EntityCategory.DIAGNOSTIC),
         ]
+
+        if demand_response_state_erd is not None:
+            sac_entities.append(
+                GeErdSensor(self, demand_response_state_erd, entity_category=EntityCategory.DIAGNOSTIC)
+            )
+        if demand_response_power_erd is not None:
+            sac_entities.append(
+                GeErdSensor(self, demand_response_power_erd, uom_override="kW", entity_category=EntityCategory.DIAGNOSTIC)
+            )
 
         entities = base_entities + sac_entities
         return entities

--- a/custom_components/ge_home/devices/wac.py
+++ b/custom_components/ge_home/devices/wac.py
@@ -18,6 +18,17 @@ class WacApi(ApplianceApi):
     def get_all_entities(self) -> List[Entity]:
         base_entities = super().get_all_entities()
 
+        demand_response_state_erd = getattr(
+            ErdCode,
+            "WAC_DEMAND_RESPONSE_STATE",
+            getattr(ErdCode, "RESOURCE_DEMAND_RESPONSE_STATE", None),
+        )
+        demand_response_power_erd = getattr(
+            ErdCode,
+            "WAC_DEMAND_RESPONSE_POWER",
+            getattr(ErdCode, "RESOURCE_DEMAND_RESPONSE_POWER", None),
+        )
+
         wac_entities = [
             GeWacClimate(self),
             GeErdSensor(self, ErdCode.AC_TARGET_TEMPERATURE, entity_category=EntityCategory.DIAGNOSTIC),
@@ -26,9 +37,17 @@ class WacApi(ApplianceApi):
             GeErdSensor(self, ErdCode.AC_OPERATION_MODE, entity_category=EntityCategory.DIAGNOSTIC),
             GeErdSwitch(self, ErdCode.AC_POWER_STATUS, bool_converter=ErdOnOffBoolConverter(), icon_on_override="mdi:power-on", icon_off_override="mdi:power-off"),
             GeErdBinarySensor(self, ErdCode.AC_FILTER_STATUS, device_class_override="problem", entity_category=EntityCategory.DIAGNOSTIC),
-            GeErdSensor(self, ErdCode.WAC_DEMAND_RESPONSE_STATE, entity_category=EntityCategory.DIAGNOSTIC),
-            GeErdSensor(self, ErdCode.WAC_DEMAND_RESPONSE_POWER, uom_override="kW", entity_category=EntityCategory.DIAGNOSTIC),
         ]
+
+        if demand_response_state_erd is not None:
+            wac_entities.append(
+                GeErdSensor(self, demand_response_state_erd, entity_category=EntityCategory.DIAGNOSTIC)
+            )
+        if demand_response_power_erd is not None:
+            wac_entities.append(
+                GeErdSensor(self, demand_response_power_erd, uom_override="kW", entity_category=EntityCategory.DIAGNOSTIC)
+            )
+
         entities = base_entities + wac_entities
         return entities
         

--- a/custom_components/ge_home/manifest.json
+++ b/custom_components/ge_home/manifest.json
@@ -5,7 +5,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "documentation": "https://github.com/simbaja/ha_gehome",
-  "requirements": ["gehomesdk==2026.2.0","magicattr==0.1.6"],
+  "requirements": ["gehomesdk==2026.5.4","magicattr==0.1.6"],
   "codeowners": ["@simbaja"],	
   "version": "2026.2.0"
 }


### PR DESCRIPTION
…ERD compat

GE/SmartHQ's newer gehomesdk (2026.5.x) renamed the AC demand-response ERD constants WAC_DEMAND_RESPONSE_STATE/POWER to RESOURCE_DEMAND_RESPONSE_*. Referencing the old names raised AttributeError during entity construction, which broke device setup.

- manifest.json: bump gehomesdk 2026.2.0 -> 2026.5.4 (upstream #519)
- wac.py / biac.py: resolve the demand-response ERDs defensively via getattr with a fallback to the renamed constants, so both old and new SDK names work (upstream #520)


Claude-Session: https://claude.ai/code/session_01WsPr7r23SR4NV8dv67wuiu