### PR TITLE
Fix oven temperature edge cases for metric F&P ovens

### DIFF
--- a/custom_components/ge_home/devices/oven.py
+++ b/custom_components/ge_home/devices/oven.py
@@ -20,6 +20,9 @@ from ..entities import (
     GeErdTimerNumber,
     GeErdBinarySensor,
     GeOven,
+    GeOvenErdTemperatureSensor,
+    GeOvenErdTemperatureOffsetSensor,
+    GeOvenErdCookModeSensor,
     GeOvenLightLevelSelect,
     GeOvenWarmingStateSelect,
     UPPER_OVEN,
@@ -83,7 +86,7 @@ class OvenApi(ApplianceApi):
         if oven_config.has_lower_oven:
             oven_entities.extend(
                 [
-                    GeErdSensor(
+                    GeOvenErdCookModeSensor(
                         self,
                         ErdCode.LOWER_OVEN_COOK_MODE,
                         entity_category=EntityCategory.DIAGNOSTIC,
@@ -100,12 +103,12 @@ class OvenApi(ApplianceApi):
                         self, ErdCode.LOWER_OVEN_KITCHEN_TIMER, suggested_uom="h"
                     ),
                     GeErdTimerNumber(self, ErdCode.LOWER_OVEN_KITCHEN_TIMER),
-                    GeErdSensor(
+                    GeOvenErdTemperatureOffsetSensor(
                         self,
                         ErdCode.LOWER_OVEN_USER_TEMP_OFFSET,
                         entity_category=EntityCategory.DIAGNOSTIC,
                     ),
-                    GeErdSensor(
+                    GeOvenErdTemperatureSensor(
                         self,
                         ErdCode.LOWER_OVEN_DISPLAY_TEMPERATURE,
                         entity_category=EntityCategory.DIAGNOSTIC,
@@ -125,7 +128,7 @@ class OvenApi(ApplianceApi):
             )
             if has_lower_raw_temperature:
                 oven_entities.append(
-                    GeErdSensor(
+                    GeOvenErdTemperatureSensor(
                         self,
                         ErdCode.LOWER_OVEN_RAW_TEMPERATURE,
                         entity_category=EntityCategory.DIAGNOSTIC,
@@ -147,7 +150,7 @@ class OvenApi(ApplianceApi):
                 )
             if has_lower_probe_temperature:
                 oven_entities.append(
-                    GeErdSensor(
+                    GeOvenErdTemperatureSensor(
                         self,
                         ErdCode.LOWER_OVEN_PROBE_DISPLAY_TEMP,
                         entity_category=EntityCategory.DIAGNOSTIC,
@@ -156,7 +159,7 @@ class OvenApi(ApplianceApi):
 
         oven_entities.extend(
             [
-                GeErdSensor(
+                GeOvenErdCookModeSensor(
                     self,
                     ErdCode.UPPER_OVEN_COOK_MODE,
                     self._single_name(
@@ -197,7 +200,7 @@ class OvenApi(ApplianceApi):
                         not oven_config.has_lower_oven
                     ),
                 ),
-                GeErdSensor(
+                GeOvenErdTemperatureOffsetSensor(
                     self,
                     ErdCode.UPPER_OVEN_USER_TEMP_OFFSET,
                     self._single_name(
@@ -206,7 +209,7 @@ class OvenApi(ApplianceApi):
                     ),
                     entity_category=EntityCategory.DIAGNOSTIC,
                 ),
-                GeErdSensor(
+                GeOvenErdTemperatureSensor(
                     self,
                     ErdCode.UPPER_OVEN_DISPLAY_TEMPERATURE,
                     self._single_name(
@@ -234,7 +237,7 @@ class OvenApi(ApplianceApi):
         )
         if has_upper_raw_temperature:
             oven_entities.append(
-                GeErdSensor(
+                GeOvenErdTemperatureSensor(
                     self,
                     ErdCode.UPPER_OVEN_RAW_TEMPERATURE,
                     self._single_name(
@@ -271,7 +274,7 @@ class OvenApi(ApplianceApi):
             )
         if has_upper_probe_temperature:
             oven_entities.append(
-                GeErdSensor(
+                GeOvenErdTemperatureSensor(
                     self,
                     ErdCode.UPPER_OVEN_PROBE_DISPLAY_TEMP,
                     self._single_name(

--- a/custom_components/ge_home/entities/oven/__init__.py
+++ b/custom_components/ge_home/entities/oven/__init__.py
@@ -1,4 +1,5 @@
 from .ge_oven import GeOven
+from .ge_oven_sensor import GeOvenErdTemperatureSensor, GeOvenErdTemperatureOffsetSensor, GeOvenErdCookModeSensor
 from .ge_oven_light_level_select import GeOvenLightLevelSelect
 from .ge_oven_warming_state_select import GeOvenWarmingStateSelect
 from .const import UPPER_OVEN, LOWER_OVEN

--- a/custom_components/ge_home/entities/oven/ge_oven.py
+++ b/custom_components/ge_home/entities/oven/ge_oven.py
@@ -79,15 +79,20 @@ class GeOven(GeAbstractWaterHeater):
 
     @property
     def current_temperature(self) -> int | None: # type: ignore
-        #DISPLAY_TEMPERATURE appears to be out of line with what's
-        #actually going on in the oven, RAW_TEMPERATURE seems to be
-        #accurate. However, it appears some devices don't have
-        #the raw temperature.  So, we'll allow an override to handle
-        #that situation (see constructor)
-        #current_temp = self.get_erd_value("DISPLAY_TEMPERATURE")
-        #if current_temp:
-        #    return current_temp
-        return self.get_erd_value(self._temperature_erd_code)
+        #RAW_TEMPERATURE tracks the cavity more accurately than
+        #DISPLAY_TEMPERATURE, so it's preferred when the appliance has it
+        #(see constructor).  However, some ovens advertise the raw ERD but
+        #never populate it (it stays 0); in that case fall back to
+        #DISPLAY_TEMPERATURE so current_temperature isn't stuck at 0.
+        current_temp = self.get_erd_value(self._temperature_erd_code)
+        if not current_temp and self._temperature_erd_code != "DISPLAY_TEMPERATURE":
+            if self.api.has_erd_code(self.get_erd_code("DISPLAY_TEMPERATURE")):
+                current_temp = self.get_erd_value("DISPLAY_TEMPERATURE")
+        # Kept numeric (not None) for the same reason as target_temperature
+        # (#457): consumers float() this value. When there is no reading, fall
+        # back to the metric-aware idle placeholder so it shows 0 in the user's
+        # unit rather than -17.8C (0F) for metric users.
+        return current_temp or self._idle_temperature_placeholder
 
     @property
     def current_operation(self) -> str | None: # type: ignore
@@ -130,12 +135,35 @@ class GeOven(GeAbstractWaterHeater):
         return self.appliance.get_erd_value(erd_code)
 
     @property
+    def _idle_temperature_placeholder(self) -> int:
+        """Numeric placeholder for when the oven reports no reading/setpoint.
+
+        target_temperature and current_temperature must stay numeric, never
+        None, or downstream consumers that float() them crash (e.g. Google
+        Assistant device-state serialization, #457).
+
+        The oven transmits temperatures in Fahrenheit and Home Assistant
+        converts to the user's unit, so a raw 0 renders as -17.8C (0F) for
+        metric users. Return the Fahrenheit value that renders as 0 in the
+        user's configured unit instead: 32F = 0C for a metric locale, 0F for
+        an imperial one. This keeps an idle oven showing a clean 0 in the
+        user's own unit while staying a real (float-able) number.
+        """
+        if self.api.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS:
+            return 32
+        return 0
+
+    @property
     def target_temperature(self) -> int | None: # type: ignore
         """Return the temperature we try to reach."""
         cook_mode = self.current_cook_setting
         if cook_mode.temperature:
             return cook_mode.temperature
-        return 0
+        # No active setpoint (oven off). Must stay numeric, not None:
+        # downstream consumers such as Google Assistant float() this value and
+        # crash on None (#457). Use the metric-aware idle placeholder so it
+        # shows 0 in the user's unit rather than -17.8C (0F) for metric users.
+        return self._idle_temperature_placeholder
 
     @property
     def min_temp(self) -> int:
@@ -189,6 +217,22 @@ class GeOven(GeAbstractWaterHeater):
         erd_code = self.get_erd_code(suffix)
         return self.appliance.get_erd_value(erd_code)
 
+    def _attr_temperature(self, suffix: str):
+        """Convert an oven temperature ERD (Fahrenheit) to the user's unit for
+        the state attributes, treating 0 as "no reading".
+
+        Home Assistant unit-converts the numeric current/target fields, but
+        attribute values are passed through verbatim, so a raw Fahrenheit
+        number (e.g. 167) would otherwise sit unconverted next to the Celsius
+        fields. Convert here, mirroring the diagnostic temperature sensors.
+        """
+        value = self.get_erd_value(suffix)
+        if not value:
+            return None
+        if self.api.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS:
+            return round((value - 32) * 5 / 9, 1)
+        return value
+
     @property
     def display_state(self) -> Optional[str]:
         erd_code = self.get_erd_code("CURRENT_STATE")
@@ -203,12 +247,12 @@ class GeOven(GeAbstractWaterHeater):
         data = {
             "display_state": self.display_state,
             "probe_present": probe_present,
-            "display_temperature": self.get_erd_value("DISPLAY_TEMPERATURE")
+            "display_temperature": self._attr_temperature("DISPLAY_TEMPERATURE"),
         }
         if self.api.has_erd_code(self.get_erd_code("RAW_TEMPERATURE")):
-            data["raw_temperature"] = self.get_erd_value("RAW_TEMPERATURE")
+            data["raw_temperature"] = self._attr_temperature("RAW_TEMPERATURE")
         if probe_present:
-            data["probe_temperature"] = self.get_erd_value("PROBE_DISPLAY_TEMP")
+            data["probe_temperature"] = self._attr_temperature("PROBE_DISPLAY_TEMP")
 
         elapsed_time = None
         cook_time_remaining = None

--- a/custom_components/ge_home/entities/oven/ge_oven_sensor.py
+++ b/custom_components/ge_home/entities/oven/ge_oven_sensor.py
@@ -1,0 +1,84 @@
+"""GE Home Sensor Entities - Oven"""
+from homeassistant.const import UnitOfTemperature
+
+from ..common import GeErdSensor
+
+
+class GeOvenErdTemperatureSensor(GeErdSensor):
+    """Oven cavity temperature sensor that treats 0 as "no reading".
+
+    The oven cavity temperature ERDs (display, raw, probe) use 0 as a
+    "no reading" sentinel: a raw-temperature ERD an appliance advertises but
+    never populates, or a display/probe temperature while the oven is idle.
+    Surfacing the 0 would convert 0F to -17.8C, so we report it as unknown
+    instead.
+
+    This is deliberately NOT used for USER_TEMP_OFFSET, where 0 is a
+    legitimate value (no offset); see GeOvenErdTemperatureOffsetSensor.
+    """
+
+    @property
+    def native_value(self):  # type: ignore
+        value = super().native_value
+        # 0 (or None) means the appliance isn't reporting a reading.
+        if not value:
+            return None
+        return value
+
+
+class GeOvenErdTemperatureOffsetSensor(GeErdSensor):
+    """Oven user temperature-offset sensor.
+
+    USER_TEMP_OFFSET is a calibration *difference*, not an absolute
+    temperature, so it must be converted as a delta (no 32-degree term):
+    Home Assistant's temperature device-class conversion would otherwise turn
+    a raw 0F into -17.8C, and a real +9F offset into -12.8C instead of +5C.
+
+    The appliance transmits the offset in Fahrenheit (like every other oven
+    temperature ERD), so we convert the raw Fahrenheit delta to the user's
+    configured unit ourselves and report it natively in that unit, leaving
+    Home Assistant nothing to re-convert.
+    """
+
+    @property
+    def native_value(self):  # type: ignore
+        value = self.appliance.get_erd_value(self.erd_code)
+        if value is None:
+            return None
+        # Raw value is a Fahrenheit difference; convert as a delta.
+        if self._temp_units == UnitOfTemperature.CELSIUS:
+            return round(value * 5 / 9, 1)
+        return value
+
+    @property
+    def native_unit_of_measurement(self):  # type: ignore
+        # native_value is already in the display unit, so report that unit to
+        # stop HA applying a second (absolute) temperature conversion.
+        return self._temp_units
+
+
+class GeOvenErdCookModeSensor(GeErdSensor):
+    """Cook-mode sensor that converts the embedded setpoint to the display unit.
+
+    The cook-mode ERD decodes to an OvenCookSetting whose temperature is in
+    Fahrenheit (like all oven temperatures). Its stringify() embeds that raw
+    number with a unit label but does not convert it, so a metric user sees
+    e.g. "Bake (356C)" for a 180C setpoint. Convert the embedded temperature
+    to the user's unit before stringifying.
+    """
+
+    @property
+    def native_value(self):  # type: ignore
+        try:
+            value = self.appliance.get_erd_value(self.erd_code)
+        except (KeyError, ValueError):
+            return None
+        if value is None:
+            return None
+        temp_units = self._temp_units
+        temperature = getattr(value, "temperature", 0)
+        # Raw setpoint is Fahrenheit; convert as an absolute temperature so the
+        # metric label matches the value ("Bake (180C)", not "Bake (356C)").
+        if temperature and temp_units == UnitOfTemperature.CELSIUS:
+            value = value._replace(temperature=round((temperature - 32) * 5 / 9))
+        return self._stringify(value, temp_units=temp_units)


### PR DESCRIPTION
## Summary

Follows the revert of #509 (03fc920). With `temperature_unit` back to Fahrenheit +
Home Assistant conversion, several temperature edge cases remain for ovens like the
Fisher & Paykel OB60 in a metric locale (verified on a BLV303518). This PR addresses them.

## The wire is Fahrenheit

The entity reports Fahrenheit and Home Assistant converts. Confirmed against hardware:
- `0x5008` min/max = `01E2007A` → 122/482 — the correct 50–250 °C range only as Fahrenheit
- `0x5109` display = `0x00AC` = 172 while preheating to 80 °C (172 °F = 78 °C); the SDK
  annotates this ERD `#Fahrenheit`
- `0x5100` setpoint set to 175 °C via the app reads 347 (= 347 °F); HA writes round-trip
  through Fahrenheit (set 223 → oven runs 105 °C)
- GE's own SmartHQ app renders these values as Fahrenheit

## Fixes

1. **`current_temperature` stuck at 0** — some ovens advertise the `RAW_TEMPERATURE` ERD
   (`0x510d`) but never populate it. Fall back to `DISPLAY_TEMPERATURE` (extends the
   existing `_temperature_code` constructor override).
2. **0 °F "no reading" sentinel → −17.8 °C for metric users** (the "idle sensors read
   −17.78 °C" symptom). Diagnostic display/raw/probe sensors now report *unknown* for a 0
   reading (`GeOvenErdTemperatureSensor`). The water_heater `target_temperature` /
   `current_temperature` stay numeric (never `None`) so consumers that `float()` them don't
   crash (#457); when there's no reading they return a metric-aware placeholder that renders
   as 0 in the user's unit (32 °F = 0 °C metric, 0 °F imperial).
3. **`USER_TEMP_OFFSET` mis-converted** — it's a temperature *difference*, not an absolute,
   so an absolute °F→°C conversion turned a 0 °F offset into −17.8 °C.
   `GeOvenErdTemperatureOffsetSensor` converts it as a delta (0 → 0, +9 °F → +5 °C).
4. **Cook-mode setpoint label** — `OvenCookSetting.stringify()` embeds the raw Fahrenheit
   setpoint with the user's unit label but doesn't convert it ("Bake (356 °C)" for a 180 °C
   setpoint). `GeOvenErdCookModeSensor` converts before stringifying ("Bake (180 °C)").
5. **State-attribute temperatures** — `display_temperature` / `raw_temperature` /
   `probe_temperature` were exposed as raw Fahrenheit (HA only converts the numeric
   current/target fields). Now converted to the user's unit (0 → `None`).

## Scope

- Builds on the #509 revert; keeps the brand framework and `VENT_BAKE` mapping intact.
- Imperial users unaffected (conversions are no-ops; placeholders return 0 °F).
- `target_temperature` / `current_temperature` remain numeric to preserve #457.

## Testing

Verified live on a metric F&P OB60 (BLV303518):
- range shows 50–250 °C; set 180 °C via HA → oven targets a true 180 °C (356 °F written)
- idle/off → target & current read 0 °C (not −17.8); `raw_temperature` sensor unknown; offset 0 °C
- cook-mode reads "Bake (180 °C)"; `display_temperature` attribute matches `current_temperature`

**Known limitation (appliance-side, not addressed):** locally-set (panel) Bake setpoints
aren't published to the cloud `0x5100` ERD until changed remotely; SmartHQ shows the same
stale value.

Re #496.
