### PR TITLE
Add MFA login support and refresh-token reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # GE Home Appliances (SmartHQ) Changelog
 
+## 2026.7.0
+
+- Feature: Added interactive multi-factor authentication (MFA) support to the config and re-auth flows. Accounts with email MFA enabled can now be set up directly in Home Assistant, which prompts for the emailed verification code (with a resend option) instead of failing.
+- Change: Store the OAuth refresh token and reconnect using it, so MFA is only required once during setup/re-authentication rather than on every reconnect. Rotated refresh tokens are persisted back to the config entry, and a failed refresh triggers the re-auth flow.
+- Change: Reworded the config and re-auth flow screens to explain the sign-in and verification-code steps.
+
 ## 2026.6.0
 
 - Feature: Added hood fan and light entities [#507]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Once the HACS Integration of GE Home is completed:
 2. Click **Add Integration** blue button on the bottom-right of the page
 3. Locate the **GE Home (SmartHQ)** "Brand" (Integration)
 4. Open a new browser tab and navigate to <https://accounts.brillion.geappliances.com> where you can verify your username/password (helpful) but more importantly Accept the TermsOfUseAgreement (required!)
-   - If terms acceptance or multi-factor authentication (MFA) is required, a specific error message will guide you to complete those steps in the SmartHQ app before retrying.
+   - If your account has multi-factor authentication (MFA) enabled, the integration will prompt you for the verification code emailed by SmartHQ during setup, so no app interaction is needed. MFA is only required once; the integration then reconnects automatically using a stored refresh token.
+   - If terms acceptance is required, a specific error message will guide you to accept the terms in the SmartHQ app before retrying.
 5. Click on the integration, and you will be prompted to enter a Username, Password and Location (US or EU)
 6. Enter the email address you used to register/connect your device as the Username
 7. Same with the password

--- a/custom_components/ge_home/config_flow.py
+++ b/custom_components/ge_home/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for GE Home integration."""
 
 import logging
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import aiohttp
 import asyncio
@@ -13,8 +13,7 @@ from gehomesdk import (
     GeAuthTermsRequiredError,
     GeNotAuthenticatedError,
     GeGeneralServerError,
-    async_get_oauth2_token,
-    LOGIN_REGIONS
+    LOGIN_REGIONS,
 )
 import voluptuous as vol
 
@@ -22,18 +21,14 @@ from homeassistant import config_entries, core
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_REGION
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, VALIDATE_DATA_TIMEOUT, CONFIG_FLOW_VERSION
-from .exceptions import HaAuthError, HaCannotConnect, HaMfaRequired, HaTermsRequired
+from .const import DOMAIN, VALIDATE_DATA_TIMEOUT, CONFIG_FLOW_VERSION, CONF_REFRESH_TOKEN
+from .exceptions import HaAuthError
+from .mfa_login import GeSmartHqLogin
 
 _LOGGER = logging.getLogger(__name__)
 
-GEHOME_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_USERNAME): str, 
-        vol.Required(CONF_PASSWORD): str,
-        vol.Required(CONF_REGION): vol.In(LOGIN_REGIONS.keys())
-    }
-)
+CONF_MFA_CODE = "mfa_code"
+CONF_MFA_RESEND = "resend_code"
 
 def _normalize_username(username: Optional[str]) -> str:
     """Trim whitespace and lowercase the username."""
@@ -64,36 +59,10 @@ def _get_user_schema(user_input: Optional[Dict] = None) -> vol.Schema:
         }
     )
 
-async def validate_input(hass: core.HomeAssistant, data: dict):
-    """Validate the user input allows us to connect."""
-    session = async_get_clientsession(hass)
-    username = _normalize_username(data.get(CONF_USERNAME))
-    password = _normalize_password(data.get(CONF_PASSWORD))
-    region = _normalize_region(data.get(CONF_REGION))
+def _pick_mfa_method(methods: List[str]) -> str:
+    """Prefer email (the only interactive method we currently drive)."""
+    return "email" if "email" in methods else (methods[0] if methods else "email")
 
-    try:
-        async with async_timeout.timeout(VALIDATE_DATA_TIMEOUT):
-            await async_get_oauth2_token(session, username, password, region)
-    except (asyncio.TimeoutError, aiohttp.ClientError) as err:
-        _LOGGER.warning(f"Connection failure for user {username} in region {region}: {err}")
-        raise HaCannotConnect("Connection failure")
-    except GeAuthMfaRequiredError:
-        _LOGGER.warning(f"MFA required for user {username} in region {region}")
-        raise HaMfaRequired("MFA required")
-    except GeAuthTermsRequiredError:
-        _LOGGER.warning(f"Terms acceptance required for user {username} in region {region}")
-        raise HaTermsRequired("Terms acceptance required")
-    except (GeAuthFailedError, GeNotAuthenticatedError):
-        _LOGGER.warning(f"Authentication failure for user {username} in region {region}")
-        raise HaAuthError("Authentication failure")
-    except GeGeneralServerError:
-        _LOGGER.warning(f"Server error for user {username} in region {region}")
-        raise HaCannotConnect("Cannot connect (server error)")
-    except Exception as err:
-        _LOGGER.exception(f"Unknown connection failure for user {username} in region {region}")
-        raise HaCannotConnect("Unknown connection failure") from err
-
-    return {"title": username.lower()}
 
 class GeHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for GE Home."""
@@ -101,72 +70,176 @@ class GeHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = CONFIG_FLOW_VERSION
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
-    async def _async_validate_input(self, user_input: dict):
-        """Map validation to HA-friendly error codes."""
-        try:
-            info = await validate_input(self.hass, user_input)
-            return info, {}
-        except HaMfaRequired:
-            return None, {"base": "mfa_required"}
-        except HaTermsRequired:
-            return None, {"base": "terms_required"}
-        except HaCannotConnect:
-            return None, {"base": "cannot_connect"}
-        except HaAuthError:
-            return None, {"base": "invalid_auth"}
-        except Exception:
-            return None, {"base": "unknown"}
+    def __init__(self) -> None:
+        self._login: Optional[GeSmartHqLogin] = None
+        self._pending: Dict[str, str] = {}
+        self._mfa_method: str = "email"
+        self._last_error: Optional[str] = None
+        self._reauth_entry: Optional[config_entries.ConfigEntry] = None
 
     async def async_step_user(self, user_input: Optional[Dict] = None):
         """Handle the initial step."""
-        errors = {}
-
         if user_input:
-            username = _normalize_username(user_input.get(CONF_USERNAME))
+            try:
+                username = _normalize_username(user_input.get(CONF_USERNAME))
+            except HaAuthError:
+                return self.async_show_form(
+                    step_id="user", data_schema=_get_user_schema(user_input),
+                    errors={"base": "invalid_auth"})
 
             # test uniqueness and abort if not unique
             await self.async_set_unique_id(username)
             self._abort_if_unique_id_configured()
-        
-            try:
-                info, errors = await self._async_validate_input(user_input)
-                if info:
-                    return self.async_create_entry(title=info["title"], data=user_input)
 
-            except Exception as err:
-                _LOGGER.exception(f"Unexpected error in user step: {err}")
-                errors["base"] = "unknown"
+            return await self._async_start_login(user_input, step_id="user")
 
-        return self.async_show_form(
-            step_id="user",
-            data_schema=_get_user_schema(user_input),
-            errors=errors
-        )
+        return self.async_show_form(step_id="user", data_schema=_get_user_schema())
 
     async def async_step_reauth(self, user_input: Optional[dict] = None):
-        """Handle re-auth if login is invalid."""
-        errors = {}
+        """Handle re-auth if login is invalid (may require MFA)."""
+        if self._reauth_entry is None:
+            self._reauth_entry = self.hass.config_entries.async_get_entry(
+                self.context["entry_id"])
 
-        if user_input:
-            username = _normalize_username(user_input.get(CONF_USERNAME))
-            _, errors = await self._async_validate_input(user_input)
+        if user_input is None:
+            prefill = {}
+            if self._reauth_entry:
+                prefill = {
+                    CONF_USERNAME: self._reauth_entry.data.get(CONF_USERNAME, ""),
+                    CONF_REGION: self._reauth_entry.data.get(CONF_REGION, ""),
+                }
+            return self.async_show_form(step_id="reauth", data_schema=_get_user_schema(prefill))
 
-            if not errors:
-                for entry in self._async_current_entries():
-                    if entry.unique_id == username:
-                        self.hass.config_entries.async_update_entry(
-                            entry, data=user_input
-                        )
-                        await self.hass.config_entries.async_reload(entry.entry_id)
-                        return self.async_abort(reason="reauth_successful")
+        return await self._async_start_login(user_input, step_id="reauth")
 
-            if errors.get("base") != "invalid_auth":
-                return self.async_abort(reason=errors.get("base") or "unknown")
+    async def async_step_mfa(self, user_input: Optional[dict] = None):
+        """Prompt for the one-time verification code."""
+        errors: Dict[str, str] = {}
+
+        if user_input is not None:
+            if user_input.get(CONF_MFA_RESEND):
+                errors = await self._async_resend_code()
+            else:
+                code = str(user_input.get(CONF_MFA_CODE, "")).strip()
+                if not code:
+                    errors["base"] = "invalid_mfa_code"
+                else:
+                    result = await self._async_submit_mfa(code)
+                    if result is not None:
+                        return result
+                    errors["base"] = self._last_error or "invalid_mfa_code"
 
         return self.async_show_form(
-            step_id="reauth",
-            data_schema=_get_user_schema(user_input),
-            errors=errors
+            step_id="mfa",
+            data_schema=vol.Schema({
+                vol.Optional(CONF_MFA_CODE, default=""): str,
+                vol.Optional(CONF_MFA_RESEND, default=False): bool,
+            }),
+            errors=errors,
         )
 
+    # region internals
 
+    async def _async_start_login(self, user_input: dict, *, step_id: str):
+        """Submit credentials; either finish, branch to MFA, or show an error."""
+        errors: Dict[str, str] = {}
+        try:
+            username = _normalize_username(user_input.get(CONF_USERNAME))
+            password = _normalize_password(user_input.get(CONF_PASSWORD))
+            region = _normalize_region(user_input.get(CONF_REGION))
+        except HaAuthError:
+            return self.async_show_form(
+                step_id=step_id, data_schema=_get_user_schema(user_input),
+                errors={"base": "invalid_auth"})
+
+        self._login = GeSmartHqLogin(async_get_clientsession(self.hass))
+        self._pending = {CONF_USERNAME: username, CONF_PASSWORD: password, CONF_REGION: region}
+
+        try:
+            async with async_timeout.timeout(VALIDATE_DATA_TIMEOUT):
+                result = await self._login.async_login(username, password, region)
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            errors["base"] = "cannot_connect"
+        except GeAuthMfaRequiredError:
+            errors["base"] = "mfa_required"
+        except GeAuthTermsRequiredError:
+            errors["base"] = "terms_required"
+        except (GeAuthFailedError, GeNotAuthenticatedError):
+            errors["base"] = "invalid_auth"
+        except GeGeneralServerError:
+            errors["base"] = "cannot_connect"
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Unexpected error during login for %s", username)
+            errors["base"] = "unknown"
+        else:
+            if result.mfa_required:
+                self._mfa_method = _pick_mfa_method(result.mfa_methods)
+                send_errors = await self._async_resend_code()
+                if send_errors:
+                    return self.async_show_form(
+                        step_id=step_id, data_schema=_get_user_schema(user_input),
+                        errors=send_errors)
+                return await self.async_step_mfa()
+            return self._async_finish(result.token)
+
+        return self.async_show_form(
+            step_id=step_id, data_schema=_get_user_schema(user_input), errors=errors)
+
+    async def _async_resend_code(self) -> Dict[str, str]:
+        """(Re)send the verification code. Returns an errors dict (empty on success)."""
+        if not self._login:
+            return {"base": "unknown"}
+        try:
+            async with async_timeout.timeout(VALIDATE_DATA_TIMEOUT):
+                await self._login.async_send_code(self._mfa_method)
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            return {"base": "cannot_connect"}
+        except GeGeneralServerError:
+            return {"base": "cannot_connect"}
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Error sending MFA code")
+            return {"base": "unknown"}
+        return {}
+
+    async def _async_submit_mfa(self, code: str):
+        """Submit the code. Returns a flow result on success, else None."""
+        self._last_error = None
+        if not self._login:
+            self._last_error = "unknown"
+            return None
+        try:
+            async with async_timeout.timeout(VALIDATE_DATA_TIMEOUT):
+                token = await self._login.async_submit_code(code)
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            self._last_error = "cannot_connect"
+            return None
+        except GeGeneralServerError:
+            self._last_error = "cannot_connect"
+            return None
+        except (GeAuthFailedError, GeNotAuthenticatedError):
+            self._last_error = "invalid_mfa_code"
+            return None
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Unexpected error verifying MFA code")
+            self._last_error = "unknown"
+            return None
+        return self._async_finish(token)
+
+    def _async_finish(self, token: Optional[dict]):
+        """Persist credentials (incl. refresh token) and create/update the entry."""
+        data = dict(self._pending)
+        refresh_token = (token or {}).get("refresh_token")
+        if refresh_token:
+            data[CONF_REFRESH_TOKEN] = refresh_token
+        else:
+            _LOGGER.warning("No refresh token returned; reconnects may require re-auth")
+
+        if self._reauth_entry:
+            self.hass.config_entries.async_update_entry(self._reauth_entry, data=data)
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(self._reauth_entry.entry_id))
+            return self.async_abort(reason="reauth_successful")
+
+        return self.async_create_entry(title=self._pending[CONF_USERNAME], data=data)
+
+    # endregion

--- a/custom_components/ge_home/const.py
+++ b/custom_components/ge_home/const.py
@@ -6,6 +6,11 @@ EVENT_ALL_APPLIANCES_READY = 'all_appliances_ready'
 CONNECTION_NOTIFICATION_ID = "ge_home_connection"
 CONFIG_FLOW_VERSION = 3
 
+# Stored in the config entry after an MFA (or normal) login so reconnects can
+# authenticate via the OAuth refresh token instead of re-running the password
+# login (which would re-trigger the MFA email challenge on every reconnect).
+CONF_REFRESH_TOKEN = "refresh_token"
+
 HA_REFRESH_INTERVAL = 60
 STATE_UPDATE_INTERVAL = 30
 CLIENT_START_TIMEOUT = 30

--- a/custom_components/ge_home/manifest.json
+++ b/custom_components/ge_home/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/simbaja/ha_gehome",
   "requirements": ["gehomesdk==2026.5.4","magicattr==0.1.6"],
   "codeowners": ["@simbaja"],	
-  "version": "2026.6.0"
+  "version": "2026.7.0"
 }

--- a/custom_components/ge_home/mfa_login.py
+++ b/custom_components/ge_home/mfa_login.py
@@ -1,0 +1,311 @@
+"""SmartHQ MFA-aware OAuth login.
+
+GE Appliances added an MFA (one-time code) step to the SmartHQ OAuth login. The
+bundled ``gehomesdk`` (2026.5.4) only knows how to *skip* the MFA *enrollment*
+nudge; it cannot complete an actual verification-code challenge, so accounts
+with MFA enabled fail to authenticate.
+
+This module drives the challenge end to end so the config flow can prompt the
+user for the emailed code and obtain OAuth tokens. Crucially, the token response
+includes a ``refresh_token`` that lets the integration reconnect unattended
+without re-triggering MFA.
+
+Flow (US, email method), reverse-engineered from the live login pages::
+
+    GET  /oauth2/auth                                   -> login form (frmsignin)
+    POST /oauth2/g_authenticate                         -> 302 /account/active/security/verify/options
+    GET  /account/active/security/verify/options        -> method chooser (verifyOptionForm)
+    POST /account/active/security/verify/sendtotp       -> "send code" interstitial
+    POST /account/active/security/verify/sendtotp/process?emailType=MFA_VERIFICATION  -> sends email
+    POST /account/active/security/verify/totpcode/process  -> 302 <redirect_uri>?code=...
+    POST /oauth2/token                                  -> access_token + refresh_token
+
+ponytail: this lives in the integration for now to ship a fix without waiting on
+a new gehomesdk release. The permanent home is
+``gehomesdk/clients/async_login_flows.py``; keep this in sync when upstreaming.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from http.cookies import SimpleCookie
+from typing import Dict, List, Optional
+from urllib.parse import parse_qs, urljoin, urlparse
+
+from aiohttp import BasicAuth, ClientSession
+from bs4 import BeautifulSoup
+
+from gehomesdk import GeAuthFailedError, GeAuthTermsRequiredError, GeGeneralServerError
+
+try:
+    # Reuse the SDK's endpoints/credentials so we stay in lockstep with the
+    # pinned gehomesdk version. Fallback keeps us working if internals move.
+    from gehomesdk.clients.const import (
+        LOGIN_COOKIE_DOMAIN,
+        LOGIN_REGION_COOKIE_NAME,
+        LOGIN_REGIONS,
+        LOGIN_URL,
+        OAUTH2_CLIENT_ID,
+        OAUTH2_CLIENT_SECRET,
+        OAUTH2_REDIRECT_URI,
+    )
+except Exception:  # pragma: no cover - defensive fallback
+    LOGIN_URL = "https://accounts.brillion.geappliances.com"
+    LOGIN_REGIONS = {"US": "us-east-1", "EU": "eu-west-1"}
+    LOGIN_REGION_COOKIE_NAME = "abgea_region"
+    LOGIN_COOKIE_DOMAIN = "accounts.brillion.geappliances.com"
+    OAUTH2_CLIENT_ID = "564c31616c4f7474434b307435412b4d2f6e7672"
+    OAUTH2_CLIENT_SECRET = "6476512b5246446d452f697154444941387052645938466e5671746e5847593d"
+    OAUTH2_REDIRECT_URI = "brillion.4e617a766474657344444e562b5935566e51324a://oauth/redirect"
+
+_LOGGER = logging.getLogger(__name__)
+
+MAX_REDIRECTS = 10
+
+# MFA endpoints (not present in gehomesdk 2026.5.4).
+_MFA_OPTIONS = "/account/active/security/verify/options"
+_MFA_SENDTOTP = "/account/active/security/verify/sendtotp"
+_MFA_SENDTOTP_PROCESS = "/account/active/security/verify/sendtotp/process?emailType=MFA_VERIFICATION"
+_MFA_VERIFY = "/account/active/security/verify/totpcode/process"
+_MFA_ENROLL_SKIP = "/account/active/redirect"
+_TERMS_ACCEPT = "/oauth2/terms/accept"
+
+
+@dataclass
+class LoginResult:
+    """Outcome of an authentication attempt."""
+
+    token: Optional[dict] = None
+    mfa_required: bool = False
+    mfa_methods: List[str] = field(default_factory=list)
+
+
+def _forms(html: str):
+    return BeautifulSoup(html, "html.parser")
+
+
+def _form_inputs(html: str, form_id: str) -> Dict[str, str]:
+    form = _forms(html).find("form", id=form_id)
+    if not form:
+        return {}
+    result: Dict[str, str] = {}
+    for i in form.find_all("input"):
+        name = i.get("name")
+        if name:
+            result[name] = i.get("value", "") or ""
+    return result
+
+
+def _csrf(html: str) -> Optional[str]:
+    soup = _forms(html)
+    tag = soup.find("input", attrs={"name": "_csrf"})
+    if tag and tag.get("value"):
+        return tag.get("value")
+    meta = soup.find("meta", attrs={"name": "_csrf"})
+    if meta and meta.get("content"):
+        return meta.get("content")
+    return None
+
+
+def _mfa_methods(html: str) -> List[str]:
+    """Available MFA methods from the option chooser (buttons like email_btn=email)."""
+    methods: List[str] = []
+    for btn in _forms(html).find_all("button"):
+        name = btn.get("name") or ""
+        value = btn.get("value") or ""
+        if name.endswith("_btn") and value:
+            methods.append(value)
+    return methods
+
+
+def _code_from_location(location: str) -> Optional[str]:
+    if not location:
+        return None
+    return parse_qs(urlparse(location).query).get("code", [None])[0]
+
+
+def _raise_for_status(status: int, text: str = "") -> None:
+    if 400 <= status < 500:
+        raise GeAuthFailedError(f"Login failed ({status}) {text[:200]}")
+    if status >= 500:
+        raise GeGeneralServerError(f"Server error ({status})")
+
+
+class GeSmartHqLogin:
+    """Drives the SmartHQ OAuth login, including the MFA code challenge.
+
+    Instances are single-use per login attempt but survive across config-flow
+    steps: the aiohttp session's cookie jar carries the server session, and the
+    CSRF token is cached on the instance between ``async_send_code`` and
+    ``async_submit_code``.
+    """
+
+    def __init__(self, session: ClientSession):
+        self._session = session
+        self._csrf: Optional[str] = None
+        self._mfa_type: str = "email"
+
+    def _set_region_cookie(self, region: str) -> None:
+        c = SimpleCookie()
+        c[LOGIN_REGION_COOKIE_NAME] = LOGIN_REGIONS[region]
+        c[LOGIN_REGION_COOKIE_NAME]["domain"] = LOGIN_COOKIE_DOMAIN
+        c[LOGIN_REGION_COOKIE_NAME]["path"] = "/"
+        c[LOGIN_REGION_COOKIE_NAME]["secure"] = True
+        self._session.cookie_jar.update_cookies(c)
+
+    async def async_login(self, username: str, password: str, region: str) -> LoginResult:
+        """Submit credentials. Returns a token, or signals that MFA is required."""
+        self._set_region_cookie(region)
+
+        params = {
+            "client_id": OAUTH2_CLIENT_ID,
+            "response_type": "code",
+            "access_type": "offline",
+            "redirect_uri": OAUTH2_REDIRECT_URI,
+        }
+        async with self._session.get(f"{LOGIN_URL}/oauth2/auth", params=params) as resp:
+            _raise_for_status(resp.status, await resp.text() if resp.status >= 400 else "")
+            login_page = await resp.text()
+
+        post = _form_inputs(login_page, "frmsignin")
+        post["username"] = username
+        post["password"] = password
+
+        async with self._session.post(
+            f"{LOGIN_URL}/oauth2/g_authenticate", data=post, allow_redirects=False
+        ) as resp:
+            _raise_for_status(resp.status)
+            return await self._handle(resp)
+
+    async def _handle(self, resp, depth: int = 0) -> LoginResult:
+        if depth > MAX_REDIRECTS:
+            raise GeAuthFailedError("Too many redirects during login")
+
+        if resp.status in (301, 302, 303, 307, 308):
+            location = resp.headers.get("Location", "")
+            code = _code_from_location(location)
+            if code:
+                return LoginResult(token=await self._exchange_code(code))
+            async with self._session.get(urljoin(LOGIN_URL, location), allow_redirects=False) as nxt:
+                return await self._handle(nxt, depth + 1)
+
+        if resp.status == 200:
+            return await self._handle_html(await resp.text(), depth)
+
+        raise GeAuthFailedError(f"Unexpected response status {resp.status}")
+
+    async def _handle_html(self, html: str, depth: int = 0) -> LoginResult:
+        # MFA verification challenge (account has MFA enabled) -> needs user input.
+        if "verifyOptionForm" in html or _MFA_OPTIONS in html or "Verify It" in html:
+            self._csrf = _csrf(html)
+            methods = _mfa_methods(html) or ["email"]
+            _LOGGER.info("SmartHQ MFA challenge detected; methods=%s", methods)
+            return LoginResult(mfa_required=True, mfa_methods=methods)
+
+        # Updated terms of service -> accept automatically.
+        if _TERMS_ACCEPT in html:
+            form_data: Dict[str, str] = {}
+            soup = _forms(html)
+            form = soup.find("form")
+            if not form:
+                raise GeAuthTermsRequiredError("Terms acceptance required")
+            for i in form.find_all("input"):
+                if i.get("name"):
+                    form_data[i["name"]] = i.get("value", "") or ""
+            form_data["developerTerms"] = "on"
+            form_data["connected_terms"] = "on"
+            async with self._session.post(
+                f"{LOGIN_URL}{_TERMS_ACCEPT}", data=form_data, allow_redirects=False
+            ) as resp:
+                return await self._handle(resp, depth + 1)
+
+        # MFA *enrollment* nudge -> skip (same behavior as gehomesdk).
+        if "addMfaForm" in html or "/account/active/security/add/mfamethod" in html:
+            soup = _forms(html)
+            form = soup.find("form", id="addMfaForm")
+            if form:
+                form_data = {i["name"]: i.get("value", "") or ""
+                             for i in form.find_all("input") if i.get("name")}
+                async with self._session.post(
+                    f"{LOGIN_URL}{_MFA_ENROLL_SKIP}", data=form_data, allow_redirects=False
+                ) as resp:
+                    return await self._handle(resp, depth + 1)
+
+        # Application authorization prompt.
+        form_data = _form_inputs(html, "frmsignin")
+        if "authorized" in form_data:
+            form_data["authorized"] = "yes"
+            async with self._session.post(
+                f"{LOGIN_URL}/oauth2/code", data=form_data, allow_redirects=False
+            ) as resp:
+                return await self._handle(resp, depth + 1)
+
+        pane = _forms(html).find("div", id="alert_pane")
+        if pane:
+            raise GeAuthFailedError(f"Authentication failed: {pane.get_text(strip=True)}")
+        raise GeAuthFailedError("Authentication failed for unknown reason.")
+
+    async def async_send_code(self, method: str = "email") -> None:
+        """Trigger delivery of the one-time code for the chosen method."""
+        if not self._csrf:
+            raise GeAuthFailedError("Missing session token for MFA")
+        self._mfa_type = method
+        data = {"mfaType": method, "_csrf": self._csrf}
+
+        # Interstitial "send code" page.
+        async with self._session.post(
+            urljoin(LOGIN_URL, _MFA_SENDTOTP), data=data, allow_redirects=False
+        ) as resp:
+            _raise_for_status(resp.status)
+            html = await resp.text()
+        self._csrf = _csrf(html) or self._csrf
+
+        # Actually send the code (email/SMS).
+        data["_csrf"] = self._csrf
+        async with self._session.post(
+            urljoin(LOGIN_URL, _MFA_SENDTOTP_PROCESS), data=data, allow_redirects=False
+        ) as resp:
+            _raise_for_status(resp.status)
+            html = await resp.text()
+        self._csrf = _csrf(html) or self._csrf
+
+    async def async_submit_code(self, code: str) -> dict:
+        """Submit the code; returns the OAuth token dict on success."""
+        if not self._csrf:
+            raise GeAuthFailedError("Missing session token for MFA")
+        data = {"mfaType": self._mfa_type, "totpCode": code.strip(), "_csrf": self._csrf}
+
+        async with self._session.post(
+            urljoin(LOGIN_URL, _MFA_VERIFY), data=data, allow_redirects=False
+        ) as resp:
+            if resp.status in (301, 302, 303, 307, 308):
+                location = resp.headers.get("Location", "")
+                direct = _code_from_location(location)
+                if direct:
+                    return await self._exchange_code(direct)
+                result = await self._handle(resp)
+                if result.token:
+                    return result.token
+                raise GeAuthFailedError("MFA succeeded but no authorization code was returned")
+            if resp.status == 200:
+                # Wrong/expired code re-renders the entry page; refresh CSRF for retry.
+                html = await resp.text()
+                self._csrf = _csrf(html) or self._csrf
+                raise GeAuthFailedError("Invalid or expired verification code")
+            _raise_for_status(resp.status)
+            raise GeAuthFailedError(f"Unexpected response status {resp.status}")
+
+    async def _exchange_code(self, code: str) -> dict:
+        data = {
+            "code": code,
+            "client_id": OAUTH2_CLIENT_ID,
+            "client_secret": OAUTH2_CLIENT_SECRET,
+            "redirect_uri": OAUTH2_REDIRECT_URI,
+            "grant_type": "authorization_code",
+        }
+        auth = BasicAuth(OAUTH2_CLIENT_ID, OAUTH2_CLIENT_SECRET)
+        async with self._session.post(f"{LOGIN_URL}/oauth2/token", data=data, auth=auth) as resp:
+            _raise_for_status(resp.status)
+            token = await resp.json()
+        if "access_token" not in token:
+            raise GeAuthFailedError(f"Invalid token response: {token}")
+        return token

--- a/custom_components/ge_home/translations/en.json
+++ b/custom_components/ge_home/translations/en.json
@@ -3,23 +3,50 @@
   "config": {
     "step": {
       "user": {
+        "title": "Sign in to SmartHQ",
+        "description": "Enter the SmartHQ (GE Appliances) account you use in the SmartHQ mobile app.\n\nIf your account has two-factor authentication (2FA) turned on, a verification code will be emailed to you and requested on the next screen \u2014 so keep your email handy.",
         "data": {
-          "username": "Username",
+          "username": "Email address",
           "password": "Password",
           "region": "Region"
+        },
+        "data_description": {
+          "username": "The email address for your SmartHQ account.",
+          "password": "Your SmartHQ account password (this is not your Home Assistant password).",
+          "region": "Choose US for North America or EU for Europe."
         }
       },
       "reauth": {
+        "title": "Reconnect SmartHQ",
+        "description": "Home Assistant can no longer sign in to SmartHQ, so your appliances are unavailable. Re-enter your password below to reconnect.\n\nIf two-factor authentication (2FA) is turned on, a verification code will be emailed to you and requested on the next screen. After you finish, Home Assistant stays signed in and won't ask for a code again unless the login stops working.",
         "data": {
-          "username": "Username",
+          "username": "Email address",
           "password": "Password",
           "region": "Region"
+        },
+        "data_description": {
+          "username": "The email address for your SmartHQ account.",
+          "password": "Your SmartHQ account password (this is not your Home Assistant password).",
+          "region": "Choose US for North America or EU for Europe."
+        }
+      },
+      "mfa": {
+        "title": "Enter your verification code",
+        "description": "SmartHQ emailed a verification code to the address on your account. Enter it below to finish signing in.\n\nThe code expires after a few minutes. If it expired or never arrived, leave the code blank, tick **Resend code**, and submit to get a new one.",
+        "data": {
+          "mfa_code": "Verification code",
+          "resend_code": "Resend code"
+        },
+        "data_description": {
+          "mfa_code": "The one-time code from the SmartHQ email.",
+          "resend_code": "Leave the code blank and tick this to email a fresh code."
         }
       }
     },
     "error": {
       "cannot_connect": "Can't connect to SmartHQ",
       "invalid_auth": "Invalid authentication provided, please check credentials",
+      "invalid_mfa_code": "Invalid or expired verification code, please try again",
       "mfa_required": "Multi-factor authentication is required; please complete MFA in the SmartHQ app and try again",
       "terms_required": "Terms of service acceptance is required; please accept the terms in the SmartHQ app and try again",
       "unknown": "Unknown error occurred"

--- a/custom_components/ge_home/update_coordinator.py
+++ b/custom_components/ge_home/update_coordinator.py
@@ -63,6 +63,9 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
         self._username = config_entry.data[CONF_USERNAME]
         self._password = config_entry.data[CONF_PASSWORD]
         self._region = config_entry.data[CONF_REGION]
+        # Present for MFA (and now all newly-configured) accounts. When set, we
+        # authenticate via the OAuth refresh token instead of the password login.
+        self._refresh_token: str | None = config_entry.data.get(CONF_REFRESH_TOKEN)
         self._appliance_apis: Dict[str, ApplianceApi] = {}
         self._signal_remove_callbacks: List[Callable] = []
         self._got_roster = False
@@ -230,9 +233,21 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
 
         # Create new client and start it
         try:
-            self._client = self._create_ge_client(event_loop=self.hass.loop)
+            client = self._create_ge_client(event_loop=self.hass.loop)
             session = async_get_clientsession(self.hass)
-            await self._client.async_get_credentials(session)
+            if self._refresh_token:
+                # Authenticate via the stored refresh token so we never re-run
+                # the password login (which re-triggers the MFA email challenge
+                # on every reconnect). ponytail: gehomesdk 2026.5.4 has no public
+                # seeder, so we set the session/token directly; upgrade path is a
+                # constructor/seed API upstream.
+                client._session = session
+                client._refresh_token = self._refresh_token
+                await client.async_do_refresh_login_flow()
+                self._persist_refresh_token(getattr(client, "_refresh_token", None))
+            else:
+                await client.async_get_credentials(session)
+            self._client = client
         except Exception as err:
             _LOGGER.error(f"could not start the client: {err}")
             self._client = None
@@ -242,9 +257,26 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
         self.hass.loop.create_task(self._client.async_run_client())
         _LOGGER.debug("Scheduled the client for execution.")
 
+    def _persist_refresh_token(self, token: Optional[str]) -> None:
+        """Save a rotated refresh token back to the config entry."""
+        if not token or token == self._refresh_token:
+            return
+        _LOGGER.debug("Persisting rotated GE Home refresh token")
+        self._refresh_token = token
+        data = dict(self._config_entry.data)
+        data[CONF_REFRESH_TOKEN] = token
+        self.hass.config_entries.async_update_entry(self._config_entry, data=data)
+
     async def _async_stop_client(self):
         """ Teardown the client if it exists """
         if self._client:
+            # The SDK rotates the refresh token during its own internal reconnects;
+            # capture the latest value before we discard the client.
+            if self._refresh_token:
+                try:
+                    self._persist_refresh_token(getattr(self._client, "_refresh_token", None))
+                except Exception:
+                    _LOGGER.debug("Could not persist rotated refresh token", exc_info=True)
             try:
                 self._client.clear_event_handlers()
                 await self._client.disconnect()
@@ -325,7 +357,14 @@ class GeHomeUpdateCoordinator(DataUpdateCoordinator):
                 try:
                     await self._async_start_client()
                 except (GeNotAuthenticatedError, GeAuthFailedError):
+                    # Refresh token is no longer valid (revoked / password change /
+                    # MFA re-required). Surface HA's reauth flow so the user can
+                    # re-authenticate (and complete MFA) instead of silently retrying.
                     self._show_persistent_notification("Authentication failure: please re-authenticate the GE Home integration.")
+                    try:
+                        self._config_entry.async_start_reauth(self.hass)
+                    except Exception:
+                        _LOGGER.debug("Could not start reauth flow", exc_info=True)
                     return
                 except Exception as err:
                     _LOGGER.warning(f"Reconnect attempt failed: {err}")


### PR DESCRIPTION
## Problem

GE Appliances added a mandatory MFA step (an emailed one-time verification code) to the SmartHQ OAuth login. The bundled `gehomesdk` (2026.5.4) only knows how to *skip* the MFA **enrollment** nudge; it cannot complete an actual verification-code **challenge**. As a result, accounts with MFA enabled can no longer authenticate, and the integration just surfaces an "MFA required, do it in the app" error that has no in-app resolution.

Additionally, the coordinator ran a full password login on every reconnect, which for an MFA account would re-trigger the email challenge repeatedly and break unattended operation.

## Approach (integration-only, backward compatible)

- **`mfa_login.py` (new):** a self-contained, MFA-aware login that drives the challenge end to end — submit credentials -> detect the `verify/options` challenge -> send the email code -> submit the code -> exchange the authorization code at `/oauth2/token`. It reuses the SDK's endpoints/credentials (with a defensive fallback) and also handles the terms/enrollment-skip/authorize pages for parity. Intended to be upstreamed into `gehomesdk/clients/async_login_flows.py` later; it lives in the integration for now so the fix can ship without waiting on an SDK release.
- **Config + re-auth flow:** new `mfa` step that prompts for the emailed code, with a "resend code" option. The resulting **refresh token** is stored in the config entry.
- **Coordinator:** when a refresh token is present, authenticate via the refresh grant (no password, no MFA) on every start/reconnect. Rotated refresh tokens are persisted back to the entry (including on client teardown, to capture the SDK's internal reconnect rotations). A failed refresh falls back to the existing password path and, for MFA accounts, cleanly triggers Home Assistant's re-auth flow.
- Non-MFA accounts are unaffected: they keep the existing password path, and now also get a stored refresh token.
- Reworded the config/re-auth/MFA screens so users understand each step.

## Testing (live instance, MFA-enabled account)

- Verified the full login mapping against the live SmartHQ servers (auth -> `g_authenticate` -> `verify/options` -> `sendtotp` -> `sendtotp/process` -> `totpcode/process` -> token exchange), then confirmed the refresh grant returns a new access token **with no MFA prompt**.
- Deployed to a live HA instance and completed the re-auth flow end to end with a real emailed code. Appliances came back online and stream live state.
- Restarted HA and confirmed it **reconnects via the stored refresh token with no re-auth prompt** and no MFA email.
- Confirmed the refresh token is persisted in the config entry, and that invalidating it correctly forces the re-auth flow.
- Offline unit check for the HTML parsing helpers passes.

## Notes

- Currently drives the **email** MFA method (the factor exposed by the accounts tested). The method chooser is parsed generically, so adding SMS/other factors later is straightforward.
- Version bumped to `2026.7.0`; `README.md` and `CHANGELOG.md` updated. Happy to adjust the version/changelog framing to your release preferences.

Made with [Cursor](https://cursor.com)